### PR TITLE
Removing spring dependency

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,7 +6,6 @@ buildscript{
 
 plugins {
     id "java"
-    id "io.spring.dependency-management" version "1.0.6.RELEASE"
     id "net.ltgt.apt-eclipse" version "0.21"
     id "net.ltgt.apt-idea" version "0.21"
     id "com.github.johnrengelman.shadow" version "5.2.0"
@@ -26,12 +25,6 @@ repositories {
     maven { url "https://jcenter.bintray.com" }
 }
 
-dependencyManagement {
-    imports {
-        mavenBom 'io.micronaut:micronaut-bom:2.0.0.M1'
-        mavenBom 'org.junit:junit-bom:5.5.2'
-    }
-}
 
 configurations {
     // for dependencies that are needed for development only
@@ -39,9 +32,11 @@ configurations {
 }
 
 dependencies {
+    annotationProcessor platform("io.micronaut:micronaut-bom:$micronautVersion")    
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut:micronaut-validation"
     annotationProcessor "io.micronaut.data:micronaut-data-processor:1.0.2"
+    implementation platform("io.micronaut:micronaut-bom:$micronautVersion")
     implementation "io.micronaut:micronaut-inject"
     implementation "io.micronaut:micronaut-validation"
     implementation "io.micronaut:micronaut-runtime"
@@ -61,11 +56,13 @@ dependencies {
     implementation "io.micronaut.configuration:micronaut-jdbc-hikari"
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
     runtimeOnly "org.fusesource.jansi:jansi:1.18"
+    testAnnotationProcessor platform("io.micronaut:micronaut-bom:$micronautVersion")
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"
     testCompile 'org.junit.jupiter:junit-jupiter-api'
     testCompile 'org.junit.jupiter:junit-jupiter-params'
     testCompile 'org.junit.platform:junit-platform-launcher'
     testCompile 'org.junit.platform:junit-platform-runner'
+    testImplementation platform("io.micronaut:micronaut-bom:$micronautVersion") 
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "io.micronaut.test:micronaut-test-junit5"
     testImplementation "org.mockito:mockito-junit-jupiter:2.22.0"

--- a/server/gradle.properties
+++ b/server/gradle.properties
@@ -1,0 +1,1 @@
+micronautVersion=2.0.0.M1


### PR DESCRIPTION
Removed spring dependency as team was not sure why it was added and I don't think we need it. Also added gradle.properties to include micronaut version and tweaked the dependencies to use that.