### PR TITLE
Add build outputs for ui and a dependency on the outputs to mitigate …

### DIFF
--- a/.github/workflows/gradle-build-development.yml
+++ b/.github/workflows/gradle-build-development.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew assembleServerAndClient
+        run: ./gradlew assemble

--- a/.github/workflows/gradle-build-feature.yml
+++ b/.github/workflows/gradle-build-feature.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Gradle package
-        run: ./gradlew assembleServerAndClient
+        run: ./gradlew assemble

--- a/.github/workflows/gradle-build-production.yml
+++ b/.github/workflows/gradle-build-production.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew assembleServerAndClient
+        run: ./gradlew assemble

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Note: Be sure that the target Google Drive folder has edit access granted to the
 
 #### Building
 1. Start the database in a Docker container by running `docker-compose up` in a terminal.
-2. In a different terminal, execute the following command twice :  `./gradlew assembleServerAndClient`
+2. In a different terminal, execute the following command :  `./gradlew assemble`
 3. Once the build is successful, execute: `./gradlew run`
 4. Open the browser to run the application at `http://localhost:8080`
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,23 +44,6 @@ sonarqube {
 //    id 'maven-publish'
 //}
 
-task copyClientResources(dependsOn: ':web-ui:build') { 
-    group = 'build'
-    description = 'Copy web-ui resources into server'
-}
-
-copyClientResources.doFirst { 
-    copy {
-        from project(':web-ui').buildDir.absolutePath
-        into "${project(':server').buildDir}/resources/main/public"
-    }
-}
-
-task assembleServerAndClient(dependsOn: ['copyClientResources', ':server:shadowJar']) { 
-    group = 'build'
-    description = 'Build combined server & client JAR'
-}
-
 // task test {
 
 // }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -28,7 +28,8 @@ repositories {
 
 configurations {
     // for dependencies that are needed for development only
-    developmentOnly 
+    developmentOnly
+    publicResources
 }
 
 dependencies {
@@ -76,6 +77,8 @@ dependencies {
     testImplementation "io.micronaut.test:micronaut-test-junit5"
     testImplementation "org.mockito:mockito-junit-jupiter:2.22.0"
     testRuntime 'org.junit.jupiter:junit-jupiter-engine'
+
+    publicResources project(':web-ui')
 }
 
 test.classpath += configurations.developmentOnly
@@ -90,6 +93,12 @@ tasks.withType(JavaCompile){
     options.compilerArgs.add('-parameters')
     options.fork = true
     options.forkOptions.jvmArgs << '-Dmicronaut.openapi.views.spec=swagger-ui.enabled=true,swagger-ui.theme=flattop'
+}
+
+processResources {
+    into('public') {
+        from configurations.publicResources
+    }
 }
 
 shadowJar {

--- a/web-ui/build.gradle
+++ b/web-ui/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id "base"
     id "com.github.node-gradle.node" version "2.2.3"
 }
 
@@ -14,7 +15,7 @@ task start(type: YarnTask, dependsOn: 'yarn') {
     args = ['run', 'start']
 }
 
-task build(type: YarnTask, dependsOn: 'yarn') {
+task build(overwrite: true, type: YarnTask, dependsOn: 'yarn') {
     group = 'build'
     description = 'Build the client bundle'
     args = ['run', 'build']
@@ -30,4 +31,8 @@ task eject(type: YarnTask, dependsOn: 'yarn') {
     group = 'other'
     description = 'Eject from the create-react-app scripts'
     args = ['run', 'eject']
+}
+
+artifacts {
+    'default' file: buildDir, type: 'directory', builtBy: yarn_run_build
 }


### PR DESCRIPTION
…the build twice need
- in server build.gradle, added dependency  and processResources into public folder
-in web-ui build.gradle, added artifacts to go into build folder
-in top level build.gradle, deleted copyClientResources/assembleServerAndClient as no longer necessary
- updated readme with new build command