### PR TITLE
Fixing a null pointer when trying to connect to GCP bean

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -50,6 +50,7 @@ micronaut:
 ---      
 datasources:
   default:
+    url: ${JDBC_URL:`jdbc:postgresql://`}
     driver-class-name: org.postgresql.Driver
     dialect: POSTGRES
     schema-generate: NONE


### PR DESCRIPTION
We were seeing a data source factory returning NULL but the exception was not throwing the reason. Took some help from Micronaut team and figured out that we need to specify the database URL in application.yml for it to work. 