### PR TITLE
Feature 80/basicauth. Setup basic auth for local, else use OAuth2

### DIFF
--- a/.github/workflows/gradle-build-development.yml
+++ b/.github/workflows/gradle-build-development.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/gradle-build-feature.yml
+++ b/.github/workflows/gradle-build-feature.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Gradle package

--- a/.github/workflows/gradle-build-production.yml
+++ b/.github/workflows/gradle-build-production.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -88,7 +88,6 @@ dependencies {
     testRuntimeOnly "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
     testImplementation "org.seleniumhq.selenium:selenium-api:$seleniumVersion"
-    testImplementation 'com.google.guava:guava:29.0-jre'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.14.3"))
 
@@ -114,7 +113,9 @@ tasks.withType(JavaCompile) {
     options.fork = true
     options.forkOptions.jvmArgs << '-Dmicronaut.openapi.views.spec=swagger-ui.enabled=true,swagger-ui.theme=flattop' << '-Dmicronaut.openapi.property.naming.strategy=KEBAB_CASE'
 
-    if(System.getenv('MICRONAUT_ENVIRONMENTS') != null && System.getenv('MICRONAUT_ENVIRONMENTS').split(',').contains('local')) {
+    String envStr = System.getenv('MICRONAUT_ENVIRONMENTS')
+    List<String> envs = envStr != null ? Arrays.asList(envStr.split(',')) : List.of() as List<String>
+    if(!envs.disjoint(List.of('test', 'local'))) {
         options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger-local'
     } else {
         options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id "groovy"
 }
 
-targetCompatibility = "1.8"
-sourceCompatibility = "1.8"
+targetCompatibility = "11"
+sourceCompatibility = "11"
 archivesBaseName = "check-ins-server"
 
 version "0.1"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -114,7 +114,7 @@ tasks.withType(JavaCompile) {
     options.fork = true
     options.forkOptions.jvmArgs << '-Dmicronaut.openapi.views.spec=swagger-ui.enabled=true,swagger-ui.theme=flattop' << '-Dmicronaut.openapi.property.naming.strategy=KEBAB_CASE'
 
-    if(System.getenv('MICRONAUT_ENVIRONMENTS').split(',').contains('local')) {
+    if(System.getenv('MICRONAUT_ENVIRONMENTS') != null && System.getenv('MICRONAUT_ENVIRONMENTS').split(',').contains('local')) {
         options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger-local'
     } else {
         options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -108,11 +108,17 @@ test {
     useJUnitPlatform()
 }
 
-tasks.withType(JavaCompile){
+tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
     options.compilerArgs.add('-parameters')
     options.fork = true
-    options.forkOptions.jvmArgs << '-Dmicronaut.openapi.views.spec=swagger-ui.enabled=true,swagger-ui.theme=flattop'
+    options.forkOptions.jvmArgs << '-Dmicronaut.openapi.views.spec=swagger-ui.enabled=true,swagger-ui.theme=flattop' << '-Dmicronaut.openapi.property.naming.strategy=KEBAB_CASE'
+
+    if(System.getenv('MICRONAUT_ENVIRONMENTS').split(',').contains('local')) {
+        options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger-local'
+    } else {
+        options.forkOptions.jvmArgs << '-Dmicronaut.openapi.additional.files=src/main/resources/swagger'
+    }
 }
 
 processResources {

--- a/server/src/main/java/com/objectcomputing/checkins/Application.java
+++ b/server/src/main/java/com/objectcomputing/checkins/Application.java
@@ -4,15 +4,15 @@ import io.micronaut.runtime.Micronaut;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
 
 @OpenAPIDefinition(
-    info = @Info(
-            title = "Check-ins Project",
-            version = "0.1",
-            description = "This web application is for uploading files and tracking skill set of team members.",
-            contact = @Contact(url = "https://objectcomputing.com", name = "OCI", email = "info@objectcomputing.com")
-    )
+        info = @Info(
+                title = "Check-ins Project",
+                version = "0.1",
+                description = "This web application is for uploading files and tracking skill set of team members.",
+                contact = @Contact(url = "https://objectcomputing.com", name = "OCI", email = "info@objectcomputing.com")
+        )
+
 )
 public class Application {
     public static void main(String[] args) {

--- a/server/src/main/java/com/objectcomputing/checkins/security/UserPasswordAuthProvider.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UserPasswordAuthProvider.java
@@ -1,0 +1,30 @@
+package com.objectcomputing.checkins.security;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.*;
+import io.reactivex.Flowable;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Requires(env = {"local"})
+@Singleton
+public class UserPasswordAuthProvider implements AuthenticationProvider {
+
+    @Inject
+    UsersStore store;
+
+    @Override
+    public Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authReq) {
+        String username = authReq.getIdentity().toString();
+        String password = authReq.getSecret().toString();
+        if (password.equals(store.getUserPassword(username))) {
+            UserDetails details = new UserDetails(username, store.getUserRole(username));
+            return Flowable.just(details);
+        } else {
+            return Flowable.just(new AuthenticationFailed());
+        }
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/security/UserPasswordAuthProvider.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UserPasswordAuthProvider.java
@@ -9,7 +9,7 @@ import org.reactivestreams.Publisher;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-@Requires(env = {"local"})
+@Requires(env = {"local", "test"})
 @Singleton
 public class UserPasswordAuthProvider implements AuthenticationProvider {
 

--- a/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
@@ -19,6 +19,6 @@ public class UsersStore {
     }
 
     public List<String> getUserRole(String username) {
-        return username != null ? roles.get(username) : new ArrayList<>();
+        return username != null ? roles.get(username) : List.of();
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
@@ -5,8 +5,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.conventions.StringConvention;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 @Requires(env = {"local"})
 @ConfigurationProperties("credentials")
@@ -20,6 +19,6 @@ public class UsersStore {
     }
 
     public List<String> getUserRole(String username) {
-        return username != null ? roles.get(username) : List.of();
+        return username != null ? roles.get(username) : new ArrayList<>();
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
@@ -7,7 +7,7 @@ import io.micronaut.core.naming.conventions.StringConvention;
 
 import java.util.*;
 
-@Requires(env = {"local"})
+@Requires(env = {"local", "test"})
 @ConfigurationProperties("credentials")
 public class UsersStore {
 

--- a/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
+++ b/server/src/main/java/com/objectcomputing/checkins/security/UsersStore.java
@@ -1,0 +1,25 @@
+package com.objectcomputing.checkins.security;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Requires(env = {"local"})
+@ConfigurationProperties("credentials")
+public class UsersStore {
+
+    @MapFormat(keyFormat = StringConvention.UNDER_SCORE_SEPARATED, transformation = MapFormat.MapTransformation.FLAT)
+    HashMap<String, List<String>> roles;
+
+    public String getUserPassword(String username) {
+        return username;
+    }
+
+    public List<String> getUserRole(String username) {
+        return username != null ? roles.get(username) : List.of();
+    }
+}

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/Role.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/Role.java
@@ -28,7 +28,7 @@ public class Role {
 
     @NotNull
     @Schema(description = "role this member has", required = true,
-            allowableValues = {ADMIN_ROLE_STR, PDL_ROLE_STR, MEMBER_ROLE_STR})
+            allowableValues = {ADMIN_ROLE, PDL_ROLE, MEMBER_ROLE})
     @TypeDef(type = DataType.OBJECT)
     private RoleType role;
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/RoleController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/RoleController.java
@@ -8,7 +8,8 @@ import io.micronaut.http.annotation.*;
 import io.micronaut.http.hateoas.JsonError;
 import io.micronaut.http.hateoas.Link;
 import io.micronaut.security.annotation.Secured;
-import io.micronaut.security.rules.SecurityRule;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import javax.annotation.Nullable;
@@ -22,7 +23,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Controller("/services/role")
-@Secured(SecurityRule.IS_ANONYMOUS)
+@Secured(RoleType.Constants.ADMIN_ROLE)
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "role")
 public class RoleController {

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/RoleCreateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/RoleCreateDTO.java
@@ -17,7 +17,7 @@ public class RoleCreateDTO {
     @Column(name = "role")
     @TypeDef(type = DataType.STRING)
     @Schema(description = "role this member has", required = true,
-            allowableValues = {ADMIN_ROLE_STR, PDL_ROLE_STR, MEMBER_ROLE_STR})
+            allowableValues = {ADMIN_ROLE, PDL_ROLE, MEMBER_ROLE})
     private RoleType role;
 
     @NotNull

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/RoleType.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/RoleType.java
@@ -11,9 +11,9 @@ public enum RoleType {
     }
 
     public static class Constants {
-        static final String ADMIN_ROLE_STR = "ADMIN";
-        static final String PDL_ROLE_STR = "PDL";
-        static final String MEMBER_ROLE_STR = "MEMBER";
+        static final String ADMIN_ROLE = "ADMIN";
+        static final String PDL_ROLE = "PDL";
+        static final String MEMBER_ROLE = "MEMBER";
     }
 }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/role/RoleType.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/role/RoleType.java
@@ -11,9 +11,9 @@ public enum RoleType {
     }
 
     public static class Constants {
-        static final String ADMIN_ROLE = "ADMIN";
-        static final String PDL_ROLE = "PDL";
-        static final String MEMBER_ROLE = "MEMBER";
+        public static final String ADMIN_ROLE = "ADMIN";
+        public static final String PDL_ROLE = "PDL";
+        public static final String MEMBER_ROLE = "MEMBER";
     }
 }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/team/TeamController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/team/TeamController.java
@@ -22,8 +22,7 @@ import io.micronaut.security.rules.SecurityRule;
 
 
 @Controller(TeamController.TEAM_CONTROLLER_PATH)
-@Secured(SecurityRule.IS_ANONYMOUS)
-// @Secured(SecurityRule.IS_AUTHENTICATED)
+@Secured({SecurityRule.IS_AUTHENTICATED})
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name="team")
 public class TeamController {

--- a/server/src/main/java/com/objectcomputing/checkins/services/teammembers/TeamMemberController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/teammembers/TeamMemberController.java
@@ -21,8 +21,7 @@ import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
 
 @Controller(TeamMemberController.TEAM_MEMBER_CONTROLLER_PATH)
-@Secured(SecurityRule.IS_ANONYMOUS)
-// @Secured(SecurityRule.IS_AUTHENTICATED)
+@Secured(SecurityRule.IS_AUTHENTICATED)
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name="team-member")
 public class TeamMemberController {

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -1,6 +1,7 @@
 micronaut:
   security:
     enabled: true
+    reject-not-found: false
 
 datasources:
   default:

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -1,5 +1,22 @@
+micronaut:
+  security:
+    enabled: true
+
 datasources:
   default:
     url: ${JDBC_URL:`jdbc:postgresql://localhost:5432/checkinsdb`}
     username: postgres
     password: 'postgres'
+
+credentials:
+  roles:
+    SUPER:
+      - ADMIN
+      - PDL
+      - MEMBER
+    ADMIN:
+      - ADMIN
+    PDL:
+      - PDL
+    MEMBER:
+      - MEMBER

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -42,6 +42,7 @@ micronaut:
         http-method: GET
         access:
           - isAnonymous()
+    reject-not-found: false
     session:
       enabled: true 
       login-success-target-url: '/'

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -47,7 +47,7 @@ micronaut:
       login-success-target-url: '/'
       unauthorized-target-url: '/unauthorized'
       forbidden-target-url: '/forbidden'
----      
+---
 datasources:
   default:
     url: ${JDBC_URL:`jdbc:postgresql:///`}

--- a/server/src/main/resources/swagger-local/openapi.yml
+++ b/server/src/main/resources/swagger-local/openapi.yml
@@ -1,0 +1,7 @@
+components:
+  securitySchemes:
+    basicAuth:
+      type: 'http'
+      scheme: 'basic'
+security:
+  - basicAuth: []

--- a/server/src/main/resources/swagger/openapi.yml
+++ b/server/src/main/resources/swagger/openapi.yml
@@ -1,0 +1,11 @@
+components:
+  securitySchemes:
+    oAuth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth'
+          scopes:
+            openid: 'Google info'
+security:
+  - oAuth: [openid]

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleControllerTest.java
@@ -19,8 +19,10 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static com.objectcomputing.checkins.services.role.RoleType.Constants.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.ADMIN_ROLE;
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -166,7 +168,7 @@ class RoleControllerTest {
 
         List<Role> roles = List.of(r);
 
-        final HttpRequest<List<Role>> request = HttpRequest.PUT("roles", roles)
+        final HttpRequest<List<Role>> request = HttpRequest.POST("roles", roles)
                 .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () ->
                 client.toBlocking().exchange(request, String.class));

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
@@ -9,7 +9,7 @@ public class RoleTypeTest {
 
     @Test
     void testConstants() {
-       RoleType.Constants dnc = new RoleType.Constants(); // Test coverage hack to get to 100%
+        RoleType.Constants dnc = new RoleType.Constants(); // Test coverage hack to get to 100%
         assertEquals(RoleType.Constants.PDL_ROLE, RoleType.PDL.name());
         assertEquals(RoleType.Constants.MEMBER_ROLE, RoleType.MEMBER.name());
         assertEquals(RoleType.Constants.ADMIN_ROLE, RoleType.ADMIN.name());
@@ -19,8 +19,8 @@ public class RoleTypeTest {
     void testValues() {
         RoleType[] roles = RoleType.values();
         assertEquals(roles.length, 3);
-        for(RoleType roleType : roles) {
-            switch(roleType) {
+        for (RoleType roleType : roles) {
+            switch (roleType) {
                 case PDL:
                     assertEquals("PDL", roleType.toString());
                     break;

--- a/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/role/RoleTypeTest.java
@@ -10,9 +10,9 @@ public class RoleTypeTest {
     @Test
     void testConstants() {
        RoleType.Constants dnc = new RoleType.Constants(); // Test coverage hack to get to 100%
-        assertEquals(RoleType.Constants.PDL_ROLE_STR, RoleType.PDL.name());
-        assertEquals(RoleType.Constants.MEMBER_ROLE_STR, RoleType.MEMBER.name());
-        assertEquals(RoleType.Constants.ADMIN_ROLE_STR, RoleType.ADMIN.name());
+        assertEquals(RoleType.Constants.PDL_ROLE, RoleType.PDL.name());
+        assertEquals(RoleType.Constants.MEMBER_ROLE, RoleType.MEMBER.name());
+        assertEquals(RoleType.Constants.ADMIN_ROLE, RoleType.ADMIN.name());
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/team/TeamControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/team/TeamControllerTest.java
@@ -1,25 +1,5 @@
 package com.objectcomputing.checkins.services.team;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.inject.Inject;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -28,24 +8,31 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.test.annotation.MicronautTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.*;
+
+import static com.objectcomputing.checkins.services.role.RoleType.Constants.MEMBER_ROLE;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 @MicronautTest
 public class TeamControllerTest {
 
-    @Inject
-    @Client("/services/team")
-    private HttpClient client;
-
-    TeamRepository mockTeamRepository = mock(TeamRepository.class);
-    Team mockTeam = mock(Team.class);
-
-
     private static String testName = "testName";
-
-
     private static final Map<String, Object> fakeBody = new HashMap<String, Object>() {{
         put("name", testName);
     }};
+    TeamRepository mockTeamRepository = mock(TeamRepository.class);
+    Team mockTeam = mock(Team.class);
+    @Inject
+    @Client("/services/team")
+    private HttpClient client;
 
     @BeforeEach
     void setup() {
@@ -57,7 +44,7 @@ public class TeamControllerTest {
     public void testFindNonExistingEndpointReturns404() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
-            client.toBlocking().exchange(HttpRequest.GET("/99"));
+            client.toBlocking().exchange(HttpRequest.GET("/99").basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         });
 
         assertNotNull(thrown.getResponse());
@@ -66,9 +53,8 @@ public class TeamControllerTest {
 
     @Test
     public void testFindNonExistingEndpointReturnsNotFound() {
-        HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
-            client.toBlocking().exchange(HttpRequest.GET("/bar?order=foo"));
-        });
+        HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () ->
+                client.toBlocking().exchange(HttpRequest.GET("/bar?order=foo").basicAuth(MEMBER_ROLE, MEMBER_ROLE)));
 
         assertNotNull(thrown.getResponse());
         assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
@@ -87,7 +73,7 @@ public class TeamControllerTest {
 
         final HttpResponse<?> response = client.toBlocking()
                 .exchange(HttpRequest
-                        .GET(String.format("/?name=%s", testName)));
+                        .GET(String.format("/?name=%s", testName)).basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         assertEquals(HttpStatus.OK, response.getStatus());
     }
 
@@ -95,23 +81,27 @@ public class TeamControllerTest {
     @Test
     public void testGetFindAll() {
 
-        Team testTeam = new Team("testName","testDescription");
-        final HttpResponse<?> responseFromPost= client.toBlocking().exchange(HttpRequest.POST("", testTeam));
+        Team testTeam = new Team("testName", "testDescription");
+        final HttpResponse<?> responseFromPost = client.toBlocking().exchange(HttpRequest.POST("", testTeam)
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE));
 
 
-        HttpRequest requestFindAll = HttpRequest.GET(String.format(""));
-        List<Team> responseFindAll = client.toBlocking().retrieve(requestFindAll, Argument.of(List.class, mockTeam.getClass()));  
-        assertTrue(responseFindAll.size()>0);
+        HttpRequest requestFindAll = HttpRequest.GET(String.format(""))
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
+        List<Team> responseFindAll = client.toBlocking().retrieve(requestFindAll, Argument.of(List.class, mockTeam.getClass()));
+        assertTrue(responseFindAll.size() > 0);
     }
 
     // test Find By Name
     @Test
     public void testGetFindByName() {
-        Team testTeam = new Team("testName","testDescription");
-        HttpResponse<Team> responseFromPost= client.toBlocking().exchange(HttpRequest.POST("", testTeam),Team.class);
+        Team testTeam = new Team("testName", "testDescription");
+        HttpResponse<Team> responseFromPost = client.toBlocking().exchange(HttpRequest.POST("", testTeam)
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE), Team.class);
 
-        HttpRequest requestFindByName = HttpRequest.GET(String.format("/?name=%s", testName));
-        List<Team> responseFindByName = client.toBlocking().retrieve(requestFindByName, Argument.of(List.class, mockTeam.getClass()));  
+        HttpRequest requestFindByName = HttpRequest.GET(String.format("/?name=%s", testName))
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE);
+        List<Team> responseFindByName = client.toBlocking().retrieve(requestFindByName, Argument.of(List.class, mockTeam.getClass()));
         assertEquals(testName, responseFindByName.get(0).getName());
 
     }
@@ -121,11 +111,12 @@ public class TeamControllerTest {
     @Test
     public void testPostSave() {
 
-        Team testTeam = new Team("testName","testDescription");
+        Team testTeam = new Team("testName", "testDescription");
 
         when(mockTeamRepository.save(testTeam)).thenReturn(testTeam);
 
-        final HttpResponse<?> response = client.toBlocking().exchange(HttpRequest.POST("", testTeam));
+        final HttpResponse<?> response = client.toBlocking().exchange(HttpRequest.POST("", testTeam)
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertNotNull(response.getContentLength());
     }
@@ -134,8 +125,9 @@ public class TeamControllerTest {
     @Test
     public void testPutUpdate() {
 
-        Team testTeam = new Team("testName","testDescription");
-        HttpResponse<Team> responseFromPost= client.toBlocking().exchange(HttpRequest.POST("", testTeam),Team.class);
+        Team testTeam = new Team("testName", "testDescription");
+        HttpResponse<Team> responseFromPost = client.toBlocking().exchange(HttpRequest.POST("", testTeam)
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE), Team.class);
 
         UUID testUuid = responseFromPost.body().getUuid();
         testTeam.setUuid(testUuid);
@@ -143,7 +135,8 @@ public class TeamControllerTest {
 
         when(mockTeamRepository.update(testTeam)).thenReturn(testTeam);
 
-        final HttpResponse<?> response = client.toBlocking().exchange(HttpRequest.PUT("", testTeam));
+        final HttpResponse<?> response = client.toBlocking().exchange(HttpRequest.PUT("", testTeam)
+                .basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         assertEquals(HttpStatus.OK, response.getStatus());
         assertNotNull(response.getContentLength());
     }
@@ -153,7 +146,8 @@ public class TeamControllerTest {
     public void testPutUpdateForEmptyInput() {
         Team testTeam = new Team();
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
-            client.toBlocking().exchange(HttpRequest.PUT("", testTeam));
+            client.toBlocking().exchange(HttpRequest.PUT("", testTeam)
+                    .basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         });
         assertNotNull(thrown);
         assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
@@ -164,7 +158,8 @@ public class TeamControllerTest {
     public void testPutUpdateWithMissingField() {
 
         HttpClientResponseException thrown = assertThrows(HttpClientResponseException.class, () -> {
-            client.toBlocking().exchange(HttpRequest.PUT("", fakeBody));
+            client.toBlocking().exchange(HttpRequest.PUT("", fakeBody)
+                    .basicAuth(MEMBER_ROLE, MEMBER_ROLE));
         });
         assertNotNull(thrown);
         assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+micronaut:
+  security:
+    enabled: true
+    reject-not-found: false
+
+credentials:
+  roles:
+    SUPER:
+      - ADMIN
+      - PDL
+      - MEMBER
+    ADMIN:
+      - ADMIN
+    PDL:
+      - PDL
+    MEMBER:
+      - MEMBER


### PR DESCRIPTION
I'm not quite sure that the OAuth2 is setup correctly in the swagger yml file, this should be vetted later. It seems to be working, but we need flesh that side out more in another story. That story would include work on the google side to add roles and to add us developers to the project as members most likely. Need a spike to look in to how to do all that.