### PR TITLE
update guild primarykey to id

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/Guild.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/Guild.java
@@ -17,11 +17,11 @@ import java.util.UUID;
 @Table(name = "guilds")
 public class Guild {
     @Id
-    @Column(name = "guildid")
+    @Column(name = "id")
     @AutoPopulated
     @TypeDef(type = DataType.STRING)
     @Schema(description = "the id of the guild", required = true)
-    private UUID guildid;
+    private UUID id;
 
     @NotBlank
     @Column(name = "name", unique = true)
@@ -37,18 +37,18 @@ public class Guild {
         this(null, name, description);
     }
 
-    public Guild(UUID guildid, String name, String description) {
-        this.guildid = guildid;
+    public Guild(UUID id, String name, String description) {
+        this.id = id;
         this.name = name;
         this.description = description;
     }
 
-    public UUID getGuildid() {
-        return guildid;
+    public UUID getId() {
+        return id;
     }
 
-    public void setGuildid(UUID guildid) {
-        this.guildid = guildid;
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public String getName() {
@@ -72,20 +72,20 @@ public class Guild {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Guild guild = (Guild) o;
-        return Objects.equals(guildid, guild.guildid) &&
+        return Objects.equals(id, guild.id) &&
                 Objects.equals(name, guild.name) &&
                 Objects.equals(description, guild.description);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guildid, name, description);
+        return Objects.hash(id, name, description);
     }
 
     @Override
     public String toString() {
         return "Guild{" +
-                "guildid=" + guildid +
+                "id=" + id +
                 ", name='" + name + '\'' +
                 ", description='" + description +
                 '}';

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildController.java
@@ -51,7 +51,7 @@ public class GuildController {
         Guild newGuild = guildService.save(new Guild(guild.getName(), guild.getDescription()));
         return HttpResponse
                 .created(newGuild)
-                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), newGuild.getGuildid()))));
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), newGuild.getId()))));
     }
 
     /**
@@ -85,13 +85,13 @@ public class GuildController {
     /**
      * Get guild based on id
      *
-     * @param guildid {@link UUID} of guild
+     * @param id {@link UUID} of guild
      * @return {@link Guild guild matching id}
      */
 
-    @Get("/{guildid}")
-    public Guild readGuild(UUID guildid) {
-        return guildService.read(guildid);
+    @Get("/{id}")
+    public Guild readGuild(UUID id) {
+        return guildService.read(id);
     }
 
     /**
@@ -119,7 +119,7 @@ public class GuildController {
         Guild updatedGuild = guildService.update(guild);
         return HttpResponse
                 .ok()
-                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), guild.getGuildid()))))
+                .headers(headers -> headers.location(URI.create(String.format("%s/%s", request.getUri(), guild.getId()))))
                 .body(updatedGuild);
 
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/GuildServicesImpl.java
@@ -20,9 +20,9 @@ public class GuildServicesImpl implements GuildServices {
     public Guild save(Guild guild) {
         Guild newGuild = null;
         if (guild != null) {
-            if (guild.getGuildid() != null) {
-                throw new GuildBadArgException(String.format("Found unexpected guildid %s, please try updating instead",
-                        guild.getGuildid()));
+            if (guild.getId() != null) {
+                throw new GuildBadArgException(String.format("Found unexpected id %s, please try updating instead",
+                        guild.getId()));
             } else if (guildsRepo.findByName(guild.getName()).isPresent()) {
                 throw new GuildBadArgException(String.format("Guild with name %s already exists", guild.getName()));
             } else {
@@ -40,10 +40,10 @@ public class GuildServicesImpl implements GuildServices {
     public Guild update(Guild guild) {
         Guild newGuild = null;
         if (guild != null) {
-            if (guild.getGuildid() != null && guildsRepo.findById(guild.getGuildid()).isPresent()) {
+            if (guild.getId() != null && guildsRepo.findById(guild.getId()).isPresent()) {
                 newGuild = guildsRepo.update(guild);
             } else {
-                throw new GuildBadArgException(String.format("Guild %s does not exist, can't update.", guild.getGuildid()));
+                throw new GuildBadArgException(String.format("Guild %s does not exist, can't update.", guild.getId()));
             }
         }
 
@@ -58,7 +58,7 @@ public class GuildServicesImpl implements GuildServices {
         }
         if (memberid != null) {
             guilds.retainAll(guildMemberRepo.findByMemberid(memberid)
-                    .stream().map(GuildMember::getGuildid).map(gid -> guildsRepo.findById(gid).orElse(null))
+                    .stream().map(GuildMember::getGuildid).map(id -> guildsRepo.findById(id).orElse(null))
                     .filter(Objects::nonNull).collect(Collectors.toSet()));
         }
         return guilds;

--- a/server/src/main/resources/db/V25__alter_guilds_table.sql
+++ b/server/src/main/resources/db/V25__alter_guilds_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE guilds
+RENAME COLUMN guildid TO id;

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildControllerTest.java
@@ -53,7 +53,7 @@ class GuildControllerTest {
 
         assertEquals(g, response.body());
         assertEquals(HttpStatus.CREATED, response.getStatus());
-        assertEquals(String.format("%s/%s", request.getPath(), g.getGuildid()), response.getHeaders().get("location"));
+        assertEquals(String.format("%s/%s", request.getPath(), g.getId()), response.getHeaders().get("location"));
 
         verify(guildService, times(1)).save(any(Guild.class));
     }
@@ -198,9 +198,9 @@ class GuildControllerTest {
     void testReadGuild() {
         Guild g = new Guild(UUID.randomUUID(), "Hello", "World");
 
-        when(guildService.read(eq(g.getGuildid()))).thenReturn(g);
+        when(guildService.read(eq(g.getId()))).thenReturn(g);
 
-        final HttpRequest<UUID> request = HttpRequest.GET(String.format("/%s", g.getGuildid().toString()));
+        final HttpRequest<UUID> request = HttpRequest.GET(String.format("/%s", g.getId().toString()));
         final HttpResponse<Guild> response = client.toBlocking().exchange(request, Guild.class);
 
         assertEquals(g, response.body());
@@ -213,9 +213,9 @@ class GuildControllerTest {
     void testReadGuildNotFound() {
         Guild g = new Guild(UUID.randomUUID(), "Hello", "World");
 
-        when(guildService.read(eq(g.getGuildid()))).thenReturn(null);
+        when(guildService.read(eq(g.getId()))).thenReturn(null);
 
-        final HttpRequest<UUID> request = HttpRequest.GET(String.format("/%s", g.getGuildid().toString()));
+        final HttpRequest<UUID> request = HttpRequest.GET(String.format("/%s", g.getId().toString()));
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class, () -> client.toBlocking().exchange(request, Guild.class));
 
         assertEquals(HttpStatus.NOT_FOUND, responseException.getStatus());
@@ -268,7 +268,7 @@ class GuildControllerTest {
 
         assertEquals(g, response.body());
         assertEquals(HttpStatus.OK, response.getStatus());
-        assertEquals(String.format("%s/%s", request.getPath(), g.getGuildid()), response.getHeaders().get("location"));
+        assertEquals(String.format("%s/%s", request.getPath(), g.getId()), response.getHeaders().get("location"));
 
         verify(guildService, times(1)).update(any(Guild.class));
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildServicesImplTest.java
@@ -48,8 +48,8 @@ class GuildServicesImplTest {
     @Test
     void testRead() {
         Guild guild = new Guild(UUID.randomUUID(), "Hello", "World");
-        when(guildRepository.findById(guild.getGuildid())).thenReturn(Optional.of(guild));
-        assertEquals(guild, services.read(guild.getGuildid()));
+        when(guildRepository.findById(guild.getId())).thenReturn(Optional.of(guild));
+        assertEquals(guild, services.read(guild.getId()));
         verify(guildRepository, times(1)).findById(any(UUID.class));
     }
 
@@ -73,7 +73,7 @@ class GuildServicesImplTest {
     void testSaveWithId() {
         Guild guild = new Guild(UUID.randomUUID(), "Wayne's", "World");
         GuildBadArgException exception = assertThrows(GuildBadArgException.class, () -> services.save(guild));
-        assertTrue(exception.getMessage().contains(String.format("unexpected guildid %s", guild.getGuildid())));
+        assertTrue(exception.getMessage().contains(String.format("unexpected id %s", guild.getId())));
         verify(guildRepository, never()).findByName(any(String.class));
         verify(guildRepository, never()).save(any(Guild.class));
     }
@@ -98,7 +98,7 @@ class GuildServicesImplTest {
     @Test
     void testUpdate() {
         Guild guild = new Guild(UUID.randomUUID(), "Dog eat dog", "World");
-        when(guildRepository.findById(eq(guild.getGuildid()))).thenReturn(Optional.of(guild));
+        when(guildRepository.findById(eq(guild.getId()))).thenReturn(Optional.of(guild));
         when(guildRepository.update(eq(guild))).thenReturn(guild);
         assertEquals(guild, services.update(guild));
         verify(guildRepository, times(1)).findById(any(UUID.class));
@@ -109,7 +109,7 @@ class GuildServicesImplTest {
     void testUpdateWithoutId() {
         Guild guild = new Guild("Bobby's", "World");
         GuildBadArgException exception = assertThrows(GuildBadArgException.class, () -> services.update(guild));
-        assertTrue(exception.getMessage().contains(String.format("%s does not exist", guild.getGuildid())));
+        assertTrue(exception.getMessage().contains(String.format("%s does not exist", guild.getId())));
         verify(guildRepository, never()).findById(any(UUID.class));
         verify(guildRepository, never()).update(any(Guild.class));
     }
@@ -117,9 +117,9 @@ class GuildServicesImplTest {
     @Test
     void testUpdateGuildDoesNotExist() {
         Guild guild = new Guild(UUID.randomUUID(), "Wayne's", "World 2");
-        when(guildRepository.findById(eq(guild.getGuildid()))).thenReturn(Optional.empty());
+        when(guildRepository.findById(eq(guild.getId()))).thenReturn(Optional.empty());
         GuildBadArgException exception = assertThrows(GuildBadArgException.class, () -> services.update(guild));
-        assertTrue(exception.getMessage().contains(String.format("%s does not exist", guild.getGuildid())));
+        assertTrue(exception.getMessage().contains(String.format("%s does not exist", guild.getId())));
         verify(guildRepository, times(1)).findById(any(UUID.class));
         verify(guildRepository, never()).update(any(Guild.class));
     }
@@ -174,9 +174,9 @@ class GuildServicesImplTest {
         final UUID memberId = UUID.randomUUID();
         List<Guild> guildToFind = List.of(guild.get(0));
         when(guildRepository.findAll()).thenReturn(guild);
-        when(guildRepository.findById(eq(guildToFind.get(0).getGuildid()))).thenReturn(Optional.of(guildToFind.get(0)));
+        when(guildRepository.findById(eq(guildToFind.get(0).getId()))).thenReturn(Optional.of(guildToFind.get(0)));
         when(guildMemberRepository.findByMemberid(eq(memberId))).thenReturn(Collections.singletonList(
-                new GuildMember(UUID.randomUUID(), guildToFind.get(0).getGuildid(), memberId, true)));
+                new GuildMember(UUID.randomUUID(), guildToFind.get(0).getId(), memberId, true)));
         assertEquals(new HashSet<>(guildToFind), services.findByFields(null, memberId));
         verify(guildRepository, times(1)).findAll();
         verify(guildRepository, times(1)).findById(any(UUID.class));
@@ -196,9 +196,9 @@ class GuildServicesImplTest {
         List<Guild> guildToFind = List.of(guild.get(0));
         when(guildRepository.findAll()).thenReturn(guild);
         when(guildRepository.findByNameIlike(eq(nameSearch))).thenReturn(guildToFind);
-        when(guildRepository.findById(eq(guildToFind.get(0).getGuildid()))).thenReturn(Optional.of(guildToFind.get(0)));
+        when(guildRepository.findById(eq(guildToFind.get(0).getId()))).thenReturn(Optional.of(guildToFind.get(0)));
         when(guildMemberRepository.findByMemberid(eq(memberId))).thenReturn(Collections.singletonList(
-                new GuildMember(UUID.randomUUID(), guildToFind.get(0).getGuildid(), memberId, true)));
+                new GuildMember(UUID.randomUUID(), guildToFind.get(0).getId(), memberId, true)));
         assertEquals(new HashSet<>(guildToFind), services.findByFields(nameSearch, memberId));
         verify(guildRepository, times(1)).findAll();
         verify(guildRepository, times(1)).findById(any(UUID.class));

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/GuildTest.java
@@ -32,11 +32,11 @@ class GuildTest {
 
     @Test
     void testGuildInstantiation2() {
-        final UUID guildid = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
         final String name = "name";
         final String description = "description";
-        Guild guild = new Guild(guildid, name, description);
-        assertEquals(guild.getGuildid(), guildid);
+        Guild guild = new Guild(id, name, description);
+        assertEquals(guild.getId(), id);
         assertEquals(guild.getName(), name);
         assertEquals(guild.getDescription(), description);
 
@@ -47,10 +47,10 @@ class GuildTest {
 
     @Test
     void testConstraintViolation() {
-        final UUID guildid = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
         final String name = "name";
         final String description = "description";
-        Guild guild = new Guild(guildid, name, description);
+        Guild guild = new Guild(id, name, description);
 
         guild.setName("");
         guild.setDescription("");
@@ -64,15 +64,15 @@ class GuildTest {
 
     @Test
     void testEquals() {
-        final UUID guildid = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
         final String name = "name";
         final String description = "description";
-        Guild g = new Guild(guildid, name, description);
-        Guild g2 = new Guild(guildid, name, description);
+        Guild g = new Guild(id, name, description);
+        Guild g2 = new Guild(id, name, description);
 
         assertEquals(g, g2);
 
-        g2.setGuildid(null);
+        g2.setId(null);
 
         assertNotEquals(g, g2);
     }
@@ -80,10 +80,10 @@ class GuildTest {
     @Test
     void testHash() {
         HashMap<Guild, Boolean> map = new HashMap<>();
-        final UUID guildid = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
         final String name = "name";
         final String description = "description";
-        Guild g = new Guild(guildid, name, description);
+        Guild g = new Guild(id, name, description);
 
         map.put(g, true);
 
@@ -92,13 +92,13 @@ class GuildTest {
 
     @Test
     void testToString() {
-        final UUID guildid = UUID.randomUUID();
+        final UUID id = UUID.randomUUID();
         final String name = "name------name";
         final String description = "description------description";
-        Guild g = new Guild(guildid, name, description);
+        Guild g = new Guild(id, name, description);
 
         assertTrue(g.toString().contains(name));
-        assertTrue(g.toString().contains(guildid.toString()));
+        assertTrue(g.toString().contains(id.toString()));
         assertTrue(g.toString().contains(description));
     }
 }


### PR DESCRIPTION
A SQL migration file 25__ added to rename the guilds table column name to "id" 
All methods entities have been altered to reflect the identity column name change