### PR TITLE
277 - speed up build/run by setting up outputs for gradle UI build

### DIFF
--- a/web-ui/build.gradle
+++ b/web-ui/build.gradle
@@ -16,12 +16,14 @@ task start(type: YarnTask, dependsOn: 'yarn') {
 }
 
 task build(overwrite: true, type: YarnTask, dependsOn: 'yarn') {
+    outputs.dir 'build'
     group = 'build'
     description = 'Build the client bundle'
     args = ['run', 'build']
 }
 
 task test(type: YarnTask, dependsOn: 'yarn') {
+    outputs.dir 'build'
     group = 'verification'
     description = 'Run the client tests'
     args = ['run', 'test']
@@ -36,3 +38,5 @@ task eject(type: YarnTask, dependsOn: 'yarn') {
 artifacts {
     'default' file: buildDir, type: 'directory', builtBy: yarn_run_build
 }
+
+yarn_run_build.outputs.dir 'build'


### PR DESCRIPTION
#277 

Proof from build output. The difference isn't as big as I'd hoped.

```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
...
> Task :web-ui:nodeSetup UP-TO-DATE
> Task :web-ui:yarnSetup UP-TO-DATE
> Task :web-ui:yarn UP-TO-DATE
> Task :web-ui:yarn_run_build UP-TO-DATE
...
> Task :server:build
> Task :web-ui:assemble UP-TO-DATE
> Task :web-ui:check UP-TO-DATE
> Task :web-ui:build UP-TO-DATE

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 5s
16 actionable tasks: 16 up-to-date
```

```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
> Task :web-ui:nodeSetup UP-TO-DATE
> Task :web-ui:yarnSetup UP-TO-DATE
> Task :web-ui:yarn UP-TO-DATE

> Task :web-ui:yarn_run_build
yarn run v1.22.5
$ react-scripts build
...

Done in 17.17s.

...
> Task :web-ui:assemble
> Task :web-ui:check UP-TO-DATE

> Task :web-ui:build
yarn run v1.22.5
$ react-scripts build
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run the following command: `npx browserslist --update-db`
Compiled successfully.

File sizes after gzip:

  276.66 KB  build\static\js\2.bbdb5004.chunk.js
  233.03 KB  build\2f193186f202aa9a48bf.worker.js
  9.5 KB     build\static\css\2.0d9e41cf.chunk.css
  9.32 KB    build\static\js\main.2ac43950.chunk.js
  1.82 KB    build\static\css\main.91094f83.chunk.css
  771 B      build\static\js\runtime-main.53fb003d.js

The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build

Find out more about deployment here:

  bit.ly/CRA-deploy

Done in 17.17s.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 40s
16 actionable tasks: 2 executed, 14 up-to-date
```