### PR TITLE
Feature 439/non blocking file service

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServices.java
@@ -10,5 +10,5 @@ public interface FileServices {
     Set<FileInfoDTO> findFiles(UUID checkInId);
     File downloadFiles(String uploadDocId);
     FileInfoDTO uploadFile(UUID checkInID, CompletedFileUpload file);
-    void deleteFile(String uploadDocId);
+    Boolean deleteFile(String uploadDocId);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
@@ -13,7 +13,7 @@ import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
 import com.objectcomputing.checkins.services.role.RoleType;
-import com.objectcomputing.checkins.util.googleapiaccess.GoogleAccessor;
+import com.objectcomputing.checkins.util.googleapiaccess.GoogleApiAccess;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.security.utils.SecurityService;
@@ -38,20 +38,20 @@ public class FileServicesImpl implements FileServices {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileServicesImpl.class);
 
-    private final GoogleAccessor googleAccessor;
+    private final GoogleApiAccess googleApiAccess;
     private final SecurityService securityService;
     private final CheckInServices checkInServices;
     private final CheckinDocumentServices checkinDocumentServices;
     private final MemberProfileServices memberProfileServices;
     private final CurrentUserServices currentUserServices;
 
-    public FileServicesImpl(GoogleAccessor googleAccessor,
+    public FileServicesImpl(GoogleApiAccess googleApiAccess,
                             SecurityService securityService,
                             CheckInServices checkInServices,
                             CheckinDocumentServices checkinDocumentServices,
                             MemberProfileServices memberProfileServices,
                             CurrentUserServices currentUserServices) {
-        this.googleAccessor = googleAccessor;
+        this.googleApiAccess = googleApiAccess;
         this.securityService = securityService;
         this.checkInServices = checkInServices;
         this.checkinDocumentServices = checkinDocumentServices;
@@ -69,7 +69,7 @@ public class FileServicesImpl implements FileServices {
 
         try {
             Set<FileInfoDTO> result = new HashSet<>();
-            Drive drive = googleAccessor.accessGoogleDrive();
+            Drive drive = googleApiAccess.getDrive();
             validate(drive == null, "Unable to access Google Drive");
 
             if (checkInID == null && isAdmin) {
@@ -123,7 +123,7 @@ public class FileServicesImpl implements FileServices {
             file.deleteOnExit();
             FileWriter myWriter = new FileWriter(file);
 
-            Drive drive = googleAccessor.accessGoogleDrive();
+            Drive drive = googleApiAccess.getDrive();
             validate(drive == null, "Unable to access Google Drive");
 
             drive.files().get(uploadDocId).executeMediaAndDownloadTo(outputStream);
@@ -159,7 +159,7 @@ public class FileServicesImpl implements FileServices {
         final String directoryName = sb;
 
         try {
-            Drive drive = googleAccessor.accessGoogleDrive();
+            Drive drive = googleApiAccess.getDrive();
             validate(drive == null, "Unable to access Google Drive");
 
             // Check if folder already exists on google drive. If exists, return folderId and name
@@ -221,7 +221,7 @@ public class FileServicesImpl implements FileServices {
         }
 
         try {
-            Drive drive = googleAccessor.accessGoogleDrive();
+            Drive drive = googleApiAccess.getDrive();
             validate(drive == null, "Unable to access Google Drive");
             drive.files().delete(uploadDocId).execute();
             checkinDocumentServices.deleteByUploadDocId(uploadDocId);

--- a/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/file/FileServicesImpl.java
@@ -206,7 +206,7 @@ public class FileServicesImpl implements FileServices {
     }
 
     @Override
-    public void deleteFile(@NotNull String uploadDocId) {
+    public Boolean deleteFile(@NotNull String uploadDocId) {
 
         String workEmail = securityService!=null ? securityService.getAuthentication().get().getAttributes().get("email").toString() : null;
         MemberProfile currentUser = workEmail!=null? currentUserServices.findOrSaveUser(null, workEmail) : null;
@@ -225,6 +225,7 @@ public class FileServicesImpl implements FileServices {
             validate(drive == null, "Unable to access Google Drive");
             drive.files().delete(uploadDocId).execute();
             checkinDocumentServices.deleteByUploadDocId(uploadDocId);
+            return true;
         } catch (IOException e) {
             LOG.error("Error occurred while retrieving files from Google Drive.", e);
             throw new FileRetrievalException(e.getMessage());

--- a/server/src/test/java/com/objectcomputing/checkins/services/file/FileControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/file/FileControllerTest.java
@@ -181,7 +181,7 @@ public class FileControllerTest {
     public void testDeleteEndpoint() {
 
         String uploadDocId = "some.upload.id";
-        doNothing().when(fileServices).deleteFile(uploadDocId);
+        when(fileServices.deleteFile(uploadDocId)).thenReturn(true);
 
         final HttpRequest<?> request = HttpRequest.DELETE(String.format("/%s", uploadDocId))
                                         .basicAuth("some.email.id", MEMBER_ROLE);

--- a/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/file/FileServicesImplTest.java
@@ -502,8 +502,9 @@ public class FileServicesImplTest {
         when(drive.files()).thenReturn(files);
         when(files.delete(uploadDocId)).thenReturn(delete);
 
-        services.deleteFile(uploadDocId);
+        Boolean result = services.deleteFile(uploadDocId);
 
+        assertTrue(result);
         verify(googleAccessor, times(1)).accessGoogleDrive();
         verify(checkinDocumentServices, times(1)).getFindByUploadDocId(uploadDocId);
         verify(checkinDocumentServices, times(1)).deleteByUploadDocId(uploadDocId);
@@ -522,8 +523,9 @@ public class FileServicesImplTest {
         when(drive.files()).thenReturn(files);
         when(files.delete(uploadDocId)).thenReturn(delete);
 
-        services.deleteFile(uploadDocId);
+        Boolean result = services.deleteFile(uploadDocId);
 
+        assertTrue(result);
         verify(googleAccessor, times(1)).accessGoogleDrive();
         verify(checkinDocumentServices, times(1)).getFindByUploadDocId(uploadDocId);
         verify(checkinDocumentServices, times(1)).deleteByUploadDocId(uploadDocId);


### PR DESCRIPTION
* Convert controller methods to non-blocking.
* File service impl was creating an instance of Drive API for every call. Updated it to use GoogleApiAccess.getDrive() instead of calling Authenticator directly.