### PR TITLE
Use numeric skill levels

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillLevel.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillLevel.java
@@ -11,6 +11,12 @@ public enum SkillLevel {
     ADVANCED(4),
     EXPERT(5);
 
+    public static final String INTERESTED_LEVEL = "1";
+    public static final String NOVICE_LEVEL = "2";
+    public static final String INTERMEDIATE_LEVEL = "3";
+    public static final String ADVANCED_LEVEL = "4";
+    public static final String EXPERT_LEVEL = "5";
+
     private final int value;
 
     SkillLevel(int value) {
@@ -24,15 +30,15 @@ public enum SkillLevel {
     public static SkillLevel convertFromString(@NotNull String level) {
         final String levelLc = level.toLowerCase();
         switch (levelLc) {
-            case "1":
+            case INTERESTED_LEVEL:
                 return SkillLevel.INTERESTED;
-            case "2":
+            case NOVICE_LEVEL:
                 return SkillLevel.NOVICE;
-            case "3":
+            case INTERMEDIATE_LEVEL:
                 return SkillLevel.INTERMEDIATE;
-            case "4":
+            case ADVANCED_LEVEL:
                 return SkillLevel.ADVANCED;
-            case "5":
+            case EXPERT_LEVEL:
                 return SkillLevel.EXPERT;
             default:
                 throw new BadArgException(String.format("Invalid skill level %s", level));

--- a/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillLevel.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillLevel.java
@@ -5,11 +5,11 @@ import com.objectcomputing.checkins.exceptions.BadArgException;
 import javax.validation.constraints.NotNull;
 
 public enum SkillLevel {
-    INTERESTED(0),
-    NOVICE(1),
-    INTERMEDIATE(2),
-    ADVANCED(3),
-    EXPERT(4);
+    INTERESTED(1),
+    NOVICE(2),
+    INTERMEDIATE(3),
+    ADVANCED(4),
+    EXPERT(5);
 
     private final int value;
 
@@ -24,15 +24,15 @@ public enum SkillLevel {
     public static SkillLevel convertFromString(@NotNull String level) {
         final String levelLc = level.toLowerCase();
         switch (levelLc) {
-            case "interested":
+            case "1":
                 return SkillLevel.INTERESTED;
-            case "novice":
+            case "2":
                 return SkillLevel.NOVICE;
-            case "intermediate":
+            case "3":
                 return SkillLevel.INTERMEDIATE;
-            case "advanced":
+            case "4":
                 return SkillLevel.ADVANCED;
-            case "expert":
+            case "5":
                 return SkillLevel.EXPERT;
             default:
                 throw new BadArgException(String.format("Invalid skill level %s", level));

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
@@ -25,9 +25,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SkillsReportControllerTest extends TestContainersSuite
         implements MemberSkillFixture, MemberProfileFixture, SkillFixture {
 
-    private final String INTERMEDIATE_LEVEL = "3";
-    private final String ADVANCED_LEVEL = "4";
-
     @Inject
     @Client("/reports/skills")
     HttpClient client;
@@ -36,7 +33,7 @@ public class SkillsReportControllerTest extends TestContainersSuite
     void testValidRequestNonEmptyResponse() {
         final MemberProfile memberProfile = createADefaultMemberProfile();
         final Skill skill = createADefaultSkill();
-        final MemberSkill memberSkill = createMemberSkill(memberProfile, skill, ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill memberSkill = createMemberSkill(memberProfile, skill, SkillLevel.ADVANCED_LEVEL, LocalDate.now());
 
         final SkillsReportRequestDTO skillsReportRequestDTO = new SkillsReportRequestDTO();
         final List<SkillLevelDTO> skillLevelDTOList = new ArrayList<>();
@@ -67,7 +64,7 @@ public class SkillsReportControllerTest extends TestContainersSuite
     void testValidRequestEmptyResponse() {
         final MemberProfile memberProfile = createADefaultMemberProfile();
         final Skill skill = createADefaultSkill();
-        createMemberSkill(memberProfile, skill, INTERMEDIATE_LEVEL, null);
+        createMemberSkill(memberProfile, skill, SkillLevel.INTERMEDIATE_LEVEL, null);
 
         final SkillsReportRequestDTO skillsReportRequestDTO = new SkillsReportRequestDTO();
         final List<SkillLevelDTO> skillLevelDTOList = new ArrayList<>();

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportControllerTest.java
@@ -25,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SkillsReportControllerTest extends TestContainersSuite
         implements MemberSkillFixture, MemberProfileFixture, SkillFixture {
 
+    private final String INTERMEDIATE_LEVEL = "3";
+    private final String ADVANCED_LEVEL = "4";
+
     @Inject
     @Client("/reports/skills")
     HttpClient client;
@@ -33,7 +36,7 @@ public class SkillsReportControllerTest extends TestContainersSuite
     void testValidRequestNonEmptyResponse() {
         final MemberProfile memberProfile = createADefaultMemberProfile();
         final Skill skill = createADefaultSkill();
-        final MemberSkill memberSkill = createMemberSkill(memberProfile, skill, "advanced", LocalDate.now());
+        final MemberSkill memberSkill = createMemberSkill(memberProfile, skill, ADVANCED_LEVEL, LocalDate.now());
 
         final SkillsReportRequestDTO skillsReportRequestDTO = new SkillsReportRequestDTO();
         final List<SkillLevelDTO> skillLevelDTOList = new ArrayList<>();
@@ -64,7 +67,7 @@ public class SkillsReportControllerTest extends TestContainersSuite
     void testValidRequestEmptyResponse() {
         final MemberProfile memberProfile = createADefaultMemberProfile();
         final Skill skill = createADefaultSkill();
-        createMemberSkill(memberProfile, skill, "intermediate", null);
+        createMemberSkill(memberProfile, skill, INTERMEDIATE_LEVEL, null);
 
         final SkillsReportRequestDTO skillsReportRequestDTO = new SkillsReportRequestDTO();
         final List<SkillLevelDTO> skillLevelDTOList = new ArrayList<>();

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportServicesImplTest.java
@@ -25,12 +25,6 @@ import static org.mockito.Mockito.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SkillsReportServicesImplTest {
 
-    private final String INTERESTED_LEVEL = "1";
-    private final String NOVICE_LEVEL = "2";
-    private final String INTERMEDIATE_LEVEL = "3";
-    private final String ADVANCED_LEVEL = "4";
-    private final String EXPERT_LEVEL = "5";
-
     @Mock
     private MemberSkillRepository memberSkillRepository;
 
@@ -116,15 +110,15 @@ public class SkillsReportServicesImplTest {
         final UUID memberId3 = UUID.randomUUID();
         final UUID memberId4 = UUID.randomUUID();
 
-        final MemberSkill ms1 = new MemberSkill(memberId1, skillId1, INTERMEDIATE_LEVEL, LocalDate.now());
-        final MemberSkill ms2 = new MemberSkill(memberId1, skillId2, ADVANCED_LEVEL, LocalDate.now());
-        final MemberSkill ms3 = new MemberSkill(memberId2, skillId3, NOVICE_LEVEL, LocalDate.now());
-        final MemberSkill ms4 = new MemberSkill(memberId2, skillId4, EXPERT_LEVEL, LocalDate.now());
-        final MemberSkill ms5 = new MemberSkill(memberId3, skillId2, INTERESTED_LEVEL, LocalDate.now());
-        final MemberSkill ms6 = new MemberSkill(memberId3, skillId3, ADVANCED_LEVEL, LocalDate.now());
-        final MemberSkill ms7 = new MemberSkill(memberId4, skillId1, ADVANCED_LEVEL, LocalDate.now());
-        final MemberSkill ms8 = new MemberSkill(memberId4, skillId2, INTERMEDIATE_LEVEL, LocalDate.now());
-        final MemberSkill ms9 = new MemberSkill(memberId4, skillId4, EXPERT_LEVEL, LocalDate.now());
+        final MemberSkill ms1 = new MemberSkill(memberId1, skillId1, SkillLevel.INTERMEDIATE_LEVEL, LocalDate.now());
+        final MemberSkill ms2 = new MemberSkill(memberId1, skillId2, SkillLevel.ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms3 = new MemberSkill(memberId2, skillId3, SkillLevel.NOVICE_LEVEL, LocalDate.now());
+        final MemberSkill ms4 = new MemberSkill(memberId2, skillId4, SkillLevel.EXPERT_LEVEL, LocalDate.now());
+        final MemberSkill ms5 = new MemberSkill(memberId3, skillId2, SkillLevel.INTERESTED_LEVEL, LocalDate.now());
+        final MemberSkill ms6 = new MemberSkill(memberId3, skillId3, SkillLevel.ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms7 = new MemberSkill(memberId4, skillId1, SkillLevel.ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms8 = new MemberSkill(memberId4, skillId2, SkillLevel.INTERMEDIATE_LEVEL, LocalDate.now());
+        final MemberSkill ms9 = new MemberSkill(memberId4, skillId4, SkillLevel.EXPERT_LEVEL, LocalDate.now());
 
         final List<MemberSkill> skillList1 = new ArrayList<>();
         skillList1.add(ms1);
@@ -249,9 +243,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : response4.getTeamMembers().get(0).getSkills()) {
             assertTrue(skill.getId().equals(skillId2) || skill.getId().equals(skillId4));
             if (skill.getId().equals(skillId2)) {
-                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.INTERMEDIATE_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString(EXPERT_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.EXPERT_LEVEL), skill.getLevel());
             }
         }
         verify(memberSkillRepository, times(11)).findBySkillid(any(UUID.class));
@@ -266,9 +260,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId1) || skill.getId().equals(skillId2));
             if (skill.getId().equals(skillId1)) {
-                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.INTERMEDIATE_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.ADVANCED_LEVEL), skill.getLevel());
             }
         }
     }
@@ -279,9 +273,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId2) || skill.getId().equals(skillId3));
             if (skill.getId().equals(skillId2)) {
-                assertEquals(SkillLevel.convertFromString(INTERESTED_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.INTERESTED_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.ADVANCED_LEVEL), skill.getLevel());
             }
         }
     }
@@ -292,9 +286,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId1) || skill.getId().equals(skillId2));
             if (skill.getId().equals(skillId1)) {
-                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.ADVANCED_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(SkillLevel.INTERMEDIATE_LEVEL), skill.getLevel());
             }
         }
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportServicesImplTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/member_skill/skillsreport/SkillsReportServicesImplTest.java
@@ -24,6 +24,13 @@ import static org.mockito.Mockito.*;
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SkillsReportServicesImplTest {
+
+    private final String INTERESTED_LEVEL = "1";
+    private final String NOVICE_LEVEL = "2";
+    private final String INTERMEDIATE_LEVEL = "3";
+    private final String ADVANCED_LEVEL = "4";
+    private final String EXPERT_LEVEL = "5";
+
     @Mock
     private MemberSkillRepository memberSkillRepository;
 
@@ -109,15 +116,15 @@ public class SkillsReportServicesImplTest {
         final UUID memberId3 = UUID.randomUUID();
         final UUID memberId4 = UUID.randomUUID();
 
-        final MemberSkill ms1 = new MemberSkill(memberId1, skillId1, "intermediate", LocalDate.now());
-        final MemberSkill ms2 = new MemberSkill(memberId1, skillId2, "advanced", LocalDate.now());
-        final MemberSkill ms3 = new MemberSkill(memberId2, skillId3, "novice", LocalDate.now());
-        final MemberSkill ms4 = new MemberSkill(memberId2, skillId4, "expert", LocalDate.now());
-        final MemberSkill ms5 = new MemberSkill(memberId3, skillId2, "interested", LocalDate.now());
-        final MemberSkill ms6 = new MemberSkill(memberId3, skillId3, "advanced", LocalDate.now());
-        final MemberSkill ms7 = new MemberSkill(memberId4, skillId1, "advanced", LocalDate.now());
-        final MemberSkill ms8 = new MemberSkill(memberId4, skillId2, "intermediate", LocalDate.now());
-        final MemberSkill ms9 = new MemberSkill(memberId4, skillId4, "expert", LocalDate.now());
+        final MemberSkill ms1 = new MemberSkill(memberId1, skillId1, INTERMEDIATE_LEVEL, LocalDate.now());
+        final MemberSkill ms2 = new MemberSkill(memberId1, skillId2, ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms3 = new MemberSkill(memberId2, skillId3, NOVICE_LEVEL, LocalDate.now());
+        final MemberSkill ms4 = new MemberSkill(memberId2, skillId4, EXPERT_LEVEL, LocalDate.now());
+        final MemberSkill ms5 = new MemberSkill(memberId3, skillId2, INTERESTED_LEVEL, LocalDate.now());
+        final MemberSkill ms6 = new MemberSkill(memberId3, skillId3, ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms7 = new MemberSkill(memberId4, skillId1, ADVANCED_LEVEL, LocalDate.now());
+        final MemberSkill ms8 = new MemberSkill(memberId4, skillId2, INTERMEDIATE_LEVEL, LocalDate.now());
+        final MemberSkill ms9 = new MemberSkill(memberId4, skillId4, EXPERT_LEVEL, LocalDate.now());
 
         final List<MemberSkill> skillList1 = new ArrayList<>();
         skillList1.add(ms1);
@@ -242,9 +249,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : response4.getTeamMembers().get(0).getSkills()) {
             assertTrue(skill.getId().equals(skillId2) || skill.getId().equals(skillId4));
             if (skill.getId().equals(skillId2)) {
-                assertEquals(SkillLevel.convertFromString("intermediate"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString("expert"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(EXPERT_LEVEL), skill.getLevel());
             }
         }
         verify(memberSkillRepository, times(11)).findBySkillid(any(UUID.class));
@@ -259,9 +266,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId1) || skill.getId().equals(skillId2));
             if (skill.getId().equals(skillId1)) {
-                assertEquals(SkillLevel.convertFromString("intermediate"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString("advanced"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
             }
         }
     }
@@ -272,9 +279,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId2) || skill.getId().equals(skillId3));
             if (skill.getId().equals(skillId2)) {
-                assertEquals(SkillLevel.convertFromString("interested"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(INTERESTED_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString("advanced"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
             }
         }
     }
@@ -285,9 +292,9 @@ public class SkillsReportServicesImplTest {
         for (SkillLevelDTO skill : elem.getSkills()) {
             assertTrue(skill.getId().equals(skillId1) || skill.getId().equals(skillId2));
             if (skill.getId().equals(skillId1)) {
-                assertEquals(SkillLevel.convertFromString("advanced"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(ADVANCED_LEVEL), skill.getLevel());
             } else {
-                assertEquals(SkillLevel.convertFromString("intermediate"), skill.getLevel());
+                assertEquals(SkillLevel.convertFromString(INTERMEDIATE_LEVEL), skill.getLevel());
             }
         }
     }


### PR DESCRIPTION
Skills report service previously assumed the skill levels in the database were strings such as "interested", "novice", "intermediate", "advanced", and "expert". But this is not correct since the database is storing the levels using strings with numeric contents "1", "2",..., "5". This PR fixes that.