### PR TITLE
DRAFT - feature-764/hide-edit-button-if-not-admin-or-lead

### DIFF
--- a/web-ui/src/components/team-results/TeamSummaryCard.jsx
+++ b/web-ui/src/components/team-results/TeamSummaryCard.jsx
@@ -125,7 +125,7 @@ const TeamSummaryCard = ({team, index}) => {
 
             </CardContent>
             <CardActions>
-                <SplitButton options={options} onClick={handleAction}/>
+                {(isAdmin || isTeamLead) && <SplitButton options={options} onClick={handleAction}/>}
             </CardActions>
             <EditTeamModal
                 team={team}


### PR DESCRIPTION
Hide edit button on team card if not admin or lead