### PR TITLE
Feature 967/create card layout for survey cards and requesties cards

### DIFF
--- a/web-ui/src/App.js
+++ b/web-ui/src/App.js
@@ -21,6 +21,7 @@ import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 
 import "./App.css";
+import FeedbackRequestPage from "./pages/FeedbackRequestPage";
 
 const customHistory = createBrowserHistory();
 
@@ -51,6 +52,9 @@ function App() {
                     <GroupIcon fontSize="large" />
                   </Header>
                   <GuildsPage />
+                </Route>
+                <Route path="/feedback/request">
+                  <FeedbackRequestPage />
                 </Route>
                 <Route path="/home">
                   <Header />

--- a/web-ui/src/App.js
+++ b/web-ui/src/App.js
@@ -22,7 +22,6 @@ import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 
 import "./App.css";
-import FeedbackRequestPage from "./pages/FeedbackRequestPage";
 
 const customHistory = createBrowserHistory();
 

--- a/web-ui/src/components/template-card/TemplateCard.css
+++ b/web-ui/src/components/template-card/TemplateCard.css
@@ -1,62 +1,62 @@
 .card {
-    width: 270px;
-    height: 250px;
-    padding: 15px;
-    margin: 20px;
-    box-shadow: #282c34;
-    font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  width: 270px;
+  height: 250px;
+  padding: 15px;
+  margin: 20px;
+  box-shadow: #282c34;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
 }
 
 .card-content {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    margin-left:  auto;
-    margin-right:  auto;
-    min-height: 170px;
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-left: auto;
+  margin-right: auto;
+  min-height: 170px;
+  height: 100%;
 }
 
 .template-name {
-    font-weight: bold;
-    text-align: center;
-    margin: auto;
-    font-size: 30px;
-    overflow: hidden;
-    max-height: 90px;
+  font-weight: bold;
+  text-align: center;
+  margin: auto;
+  font-size: 30px;
+  overflow: hidden;
+  max-height: 90px;
 }
 
 .description-and-creator {
-    display: flex;
-    padding: 0;
-    flex-direction: column;
+  display: flex;
+  padding: 0;
+  flex-direction: column;
 }
 
 .description {
-    text-align: center;
-    min-height: 60px;
-    max-height: 80px;
-    max-width: 200px;
-    color: gray;
+  text-align: center;
+  min-height: 60px;
+  max-height: 80px;
+  max-width: 200px;
+  color: gray;
 }
 
 .creator-wrapper {
-    display: flex;
-    margin-left: auto;
-    margin-right: auto;
+  display: flex;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .creator {
-    font-weight: bold;
-    text-align: center;
-    margin-left: 2px;
-    flex-direction: row;
+  font-weight: bold;
+  text-align: center;
+  margin-left: 2px;
+  flex-direction: row;
 }
 
 .title {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .pos {
-    margin-bottom: 12px;
+  margin-bottom: 12px;
 }

--- a/web-ui/src/components/template-card/TemplateCard.css
+++ b/web-ui/src/components/template-card/TemplateCard.css
@@ -17,7 +17,7 @@
   height: 100%;
 }
 
-.template-name {
+.feedback-template-card .template-name {
   font-weight: bold;
   text-align: center;
   margin: auto;
@@ -26,13 +26,13 @@
   max-height: 90px;
 }
 
-.description-and-creator {
+.feedback-template-card .description-and-creator {
   display: flex;
   padding: 0;
   flex-direction: column;
 }
 
-.description {
+.feedback-template-card .description {
   text-align: center;
   min-height: 60px;
   max-height: 80px;
@@ -40,13 +40,13 @@
   color: gray;
 }
 
-.creator-wrapper {
+.feedback-template-card .creator-wrapper {
   display: flex;
   margin-left: auto;
   margin-right: auto;
 }
 
-.creator {
+.feedback-template-card .creator {
   font-weight: bold;
   text-align: center;
   margin-left: 2px;

--- a/web-ui/src/components/template-card/TemplateCard.css
+++ b/web-ui/src/components/template-card/TemplateCard.css
@@ -1,6 +1,6 @@
-.card{
-    width: 220px;
-    height: 190px;
+.card {
+    width: 270px;
+    height: 250px;
     padding: 15px;
     margin: 20px;
     box-shadow: #282c34;

--- a/web-ui/src/components/template-card/TemplateCard.css
+++ b/web-ui/src/components/template-card/TemplateCard.css
@@ -2,46 +2,55 @@
     width: 220px;
     height: 190px;
     padding: 15px;
+    margin: 20px;
     box-shadow: #282c34;
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-
 }
-.card-content{
+
+.card-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
     margin-left:  auto;
     margin-right:  auto;
+    min-height: 170px;
+    height: 100%;
 }
 
-.templateName{
-
+.template-name {
     font-weight: bold;
     text-align: center;
     margin: auto;
     font-size: 30px;
+    overflow: hidden;
+    max-height: 90px;
 }
-.description-and-creator{
+
+.description-and-creator {
     display: flex;
-    padding: 0px;
+    padding: 0;
     flex-direction: column;
 }
-.description{
+
+.description {
     text-align: center;
     min-height: 60px;
-    max-height: 120px;
+    max-height: 80px;
     max-width: 200px;
     color: gray;
 }
-.creator-wrapper{
+
+.creator-wrapper {
     display: flex;
-    padding-top: 20px;
-    margin-left:  auto;
-    margin-right:  auto;
+    margin-left: auto;
+    margin-right: auto;
 }
-.creator{
+
+.creator {
     font-weight: bold;
     text-align: center;
     margin-left: 2px;
     flex-direction: row;
-
 }
 
 .title {

--- a/web-ui/src/components/template-card/TemplateCard.js
+++ b/web-ui/src/components/template-card/TemplateCard.js
@@ -1,30 +1,43 @@
 import React from "react";
-import "./TemplateCard.css"
+import PropTypes from "prop-types";
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 
-const templateCard = () => {
-    const templateName = "Ad Hoc"
-    const description = "Ask a single question"
-    const creator = "Admin"
+import "./TemplateCard.css"
 
+const propTypes = {
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    creator: PropTypes.string.isRequired
+}
+
+const cutText = (text, maxCharacters) => {
+    let shortenedText = text;
+    if (text.length > maxCharacters) {
+        shortenedText = `${text.substring(0, maxCharacters)}...`;
+    }
+    return shortenedText;
+}
+
+const TemplateCard = (props) => {
     return (
         <Card className = 'card'>
             <CardContent>
                 <div className='card-content'>
-                    <div className='templateName' >
-                        {templateName}
-                    </div>
-                    <div className='description-and-creator'>
-                        <div className='description'>
-                            {description}
+                    <div>
+                        <div className='template-name'>
+                            {cutText(props.title, 20)}
                         </div>
-
-                        <div className='creator-wrapper'>
-                            Created by:
-                            <div className='creator'>
-                                {creator}
+                        <div className='description-and-creator'>
+                            <div className='description'>
+                                {cutText(props.description, 90)}
                             </div>
+                        </div>
+                    </div>
+                    <div className='creator-wrapper'>
+                        Created by:
+                        <div className='creator'>
+                            {props.creator}
                         </div>
                     </div>
                </div>
@@ -34,4 +47,6 @@ const templateCard = () => {
 
 }
 
-export default templateCard;
+TemplateCard.propTypes = propTypes;
+
+export default TemplateCard;

--- a/web-ui/src/components/template-card/TemplateCard.stories.js
+++ b/web-ui/src/components/template-card/TemplateCard.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+import TemplateCard from "./TemplateCard";
+
+export default {
+  title: "Check Ins/TemplateCard",
+  component: TemplateCard
+};
+
+const Template = (args) => <TemplateCard {...args} />;
+
+export const TemplateCardDefault = Template.bind({});
+TemplateCardDefault.args = {
+  title: "",
+  description: "",
+  creator: ""
+};
+
+export const SetTemplateCard = Template.bind({});
+SetTemplateCard.args = {
+  title: "Template",
+  description: "An example feedback template",
+  creator: "Admin"
+};

--- a/web-ui/src/components/template-card/TemplateCard.test.js
+++ b/web-ui/src/components/template-card/TemplateCard.test.js
@@ -5,7 +5,11 @@ import { AppContextProvider } from "../../context/AppContext";
 it("renders correctly", () => {
     snapshot(
         <AppContextProvider >
-            <TemplateCard />
+            <TemplateCard
+              title="Template"
+              description="Sample feedback template"
+              creator="Admin"
+            />
         </AppContextProvider>
     );
 });

--- a/web-ui/src/components/template-card/__snapshots__/TemplateCard.test.js.snap
+++ b/web-ui/src/components/template-card/__snapshots__/TemplateCard.test.js.snap
@@ -10,28 +10,30 @@ exports[`renders correctly 1`] = `
     <div
       className="card-content"
     >
-      <div
-        className="templateName"
-      >
-        Ad Hoc
-      </div>
-      <div
-        className="description-and-creator"
-      >
+      <div>
         <div
-          className="description"
+          className="template-name"
         >
-          Ask a single question
+          Template
         </div>
         <div
-          className="creator-wrapper"
+          className="description-and-creator"
         >
-          Created by:
           <div
-            className="creator"
+            className="description"
           >
-            Admin
+            Sample feedback template
           </div>
+        </div>
+      </div>
+      <div
+        className="creator-wrapper"
+      >
+        Created by:
+        <div
+          className="creator"
+        >
+          Admin
         </div>
       </div>
     </div>

--- a/web-ui/src/pages/FeedbackRequestPage.css
+++ b/web-ui/src/pages/FeedbackRequestPage.css
@@ -9,3 +9,8 @@
     align-items: center;
     margin-bottom: 20px;
 }
+
+.card-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+}

--- a/web-ui/src/pages/FeedbackRequestPage.css
+++ b/web-ui/src/pages/FeedbackRequestPage.css
@@ -11,6 +11,8 @@
 }
 
 .card-container {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    margin: 1rem calc(2rem - 20px) 1rem calc(2rem - 20px);
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
 }

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -5,6 +5,7 @@ import Step from "@material-ui/core/Step";
 import StepLabel from "@material-ui/core/StepLabel";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
+import TemplateCard from "../components/template-card/TemplateCard"
 
 import "./FeedbackRequestPage.css";
 

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -76,9 +76,32 @@ const FeedbackRequestPage = () => {
                 {/* Render components conditionally based on current step */}
                 {/* if step==0 then render step0 */}
                 {/* etc... */}
+              {activeStep === 0 &&
+                <div className="card-container">
+                  <TemplateCard
+                    title="Ad Hoc"
+                    description="Send a single question"
+                    creator="Admin"
+                  />
+                  <TemplateCard
+                    title="Survey 1"
+                    description="Make a survey of a few questions"
+                    creator="Admin"
+                  />
+                  <TemplateCard
+                    title="Feedback Survey 2"
+                    description="Another type of survey"
+                    creator="Jane Doe"
+                  />
+                  <TemplateCard
+                    title="Custom Template"
+                    description="A very very very very very very very very very very very very very very very very very very very very very very very very very very long description"
+                    creator="Bob Smith"
+                  />
+                </div>
+              }
             </div>
         </div>
-        
     );
 }
 

--- a/web-ui/src/pages/__snapshots__/FeedbackRequestPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/FeedbackRequestPage.test.js.snap
@@ -264,7 +264,7 @@ exports[`renders correctly 1`] = `
       className="card-container"
     >
       <div
-        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+        className="MuiPaper-root MuiCard-root feedback-template-card MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
           className="MuiCardContent-root"
@@ -302,7 +302,7 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+        className="MuiPaper-root MuiCard-root feedback-template-card MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
           className="MuiCardContent-root"
@@ -340,7 +340,7 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+        className="MuiPaper-root MuiCard-root feedback-template-card MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
           className="MuiCardContent-root"
@@ -378,7 +378,7 @@ exports[`renders correctly 1`] = `
         </div>
       </div>
       <div
-        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+        className="MuiPaper-root MuiCard-root feedback-template-card MuiPaper-elevation1 MuiPaper-rounded"
       >
         <div
           className="MuiCardContent-root"

--- a/web-ui/src/pages/__snapshots__/FeedbackRequestPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/FeedbackRequestPage.test.js.snap
@@ -259,6 +259,163 @@ exports[`renders correctly 1`] = `
   </div>
   <div
     className="current-step-content"
-  />
+  >
+    <div
+      className="card-container"
+    >
+      <div
+        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          className="MuiCardContent-root"
+        >
+          <div
+            className="card-content"
+          >
+            <div>
+              <div
+                className="template-name"
+              >
+                Ad Hoc
+              </div>
+              <div
+                className="description-and-creator"
+              >
+                <div
+                  className="description"
+                >
+                  Send a single question
+                </div>
+              </div>
+            </div>
+            <div
+              className="creator-wrapper"
+            >
+              Created by:
+              <div
+                className="creator"
+              >
+                Admin
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          className="MuiCardContent-root"
+        >
+          <div
+            className="card-content"
+          >
+            <div>
+              <div
+                className="template-name"
+              >
+                Survey 1
+              </div>
+              <div
+                className="description-and-creator"
+              >
+                <div
+                  className="description"
+                >
+                  Make a survey of a few questions
+                </div>
+              </div>
+            </div>
+            <div
+              className="creator-wrapper"
+            >
+              Created by:
+              <div
+                className="creator"
+              >
+                Admin
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          className="MuiCardContent-root"
+        >
+          <div
+            className="card-content"
+          >
+            <div>
+              <div
+                className="template-name"
+              >
+                Feedback Survey 2
+              </div>
+              <div
+                className="description-and-creator"
+              >
+                <div
+                  className="description"
+                >
+                  Another type of survey
+                </div>
+              </div>
+            </div>
+            <div
+              className="creator-wrapper"
+            >
+              Created by:
+              <div
+                className="creator"
+              >
+                Jane Doe
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiPaper-root MuiCard-root card MuiPaper-elevation1 MuiPaper-rounded"
+      >
+        <div
+          className="MuiCardContent-root"
+        >
+          <div
+            className="card-content"
+          >
+            <div>
+              <div
+                className="template-name"
+              >
+                Custom Template
+              </div>
+              <div
+                className="description-and-creator"
+              >
+                <div
+                  className="description"
+                >
+                  A very very very very very very very very very very very very very very very very very ver...
+                </div>
+              </div>
+            </div>
+            <div
+              className="creator-wrapper"
+            >
+              Created by:
+              <div
+                className="creator"
+              >
+                Bob Smith
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
- Added `TemplateCard` to Storybook (missing from PR #989)
- A sample of `TemplateCard`s align themselves as a grid in the first step of requesting feedback
- The cards re-align responsively to page size

To test this, go to `/feedback/request` and look at **Step 1:  Select template**

Closes #967 