### PR TITLE
Bugfix 1036/fix team skills nav link

### DIFF
--- a/web-ui/src/components/menu/Menu.jsx
+++ b/web-ui/src/components/menu/Menu.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { AppContext } from "../../context/AppContext";
 import { getAvatarURL } from "../../api/api";
 
@@ -75,16 +75,22 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const isDirectoryOpen = (loc) => {
-  if (loc === "/guilds" || loc === "/people" || loc === "/teams") {
-    return true;
-  }
-  return false;
-}
 
-const isReportsOpen = (loc) => {
-  if (loc === "/checkins-reports" || loc === "/skills-reports") {
-    return true;
+const directoryLinks = [
+  ["/guilds", "GUILDS"], 
+  ["/people", "PEOPLE"], 
+  ["/teams", "TEAMS"]
+]
+
+const reportsLinks = [
+  ["/checkins-reports", "CHECK-INS"], 
+  ["/skills-reports", "SKILLS"],
+  ["/team-skills-reports", "TEAM SKILLS"]
+]
+
+const isCollapsibleListOpen = (linksArr, loc) => {
+  for (let i = 0; i < linksArr.length; i++){
+    if (linksArr[i][0] === loc) return true;
   }
   return false;
 }
@@ -101,14 +107,17 @@ function Menu() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [open, setOpen] = useState(false);
   const location = useLocation();
-  const history = useHistory();
-  const [reportsOpen, setReportsOpen] = useState(isReportsOpen(location.pathname));
-  const [directoryOpen, setDirectoryOpen] = useState(isDirectoryOpen(location.pathname));
+  const [directoryOpen, setDirectoryOpen] = useState(
+    isCollapsibleListOpen(directoryLinks, location.pathname)
+    );
+  const [reportsOpen, setReportsOpen] = useState(
+    isCollapsibleListOpen(reportsLinks, location.pathname)
+    );
   const anchorRef = useRef(null);
-
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
   };
+
 
   // return focus to the button when we transitioned from !open -> open
   const prevOpen = useRef(open);
@@ -146,12 +155,13 @@ function Menu() {
     return (
       <ListItem
         key={path}
+        component={Link}
+        to={path}
         className={isSubLink? `${classes.listItem} ${classes.nested}` : classes.listItem}
         button
         onClick={isSubLink? 
-          () => history.push(path): 
+          undefined: 
           () => {
-            history.push(path)
             closeSubMenus()
           }
         }
@@ -168,6 +178,7 @@ function Menu() {
       return createLinkJsx(path, name, isSublink);
     })
   }
+
 
   const drawer = (
     <div>
@@ -198,14 +209,7 @@ function Menu() {
       </Button>
       <Collapse in={directoryOpen} timeout="auto" unmountOnExit>
         <List className={classes.listStyle} component="nav" disablePadding>
-          {createListJsx(
-            [
-              ["/guilds", "GUILDS"], 
-              ["/people", "PEOPLE"], 
-              ["/teams", "TEAMS"]
-            ], 
-              true)
-          }
+          {createListJsx(directoryLinks, true)}
         </List>
       </Collapse>
       {isAdmin && (
@@ -219,14 +223,7 @@ function Menu() {
           </Button>
           <List className={classes.listStyle} component="nav" disablePadding>
             <Collapse in={reportsOpen} timeout="auto" unmountOnExit>
-                {createListJsx(
-                  [
-                    ["/checkins-reports", "CHECK-INS"], 
-                    ["/skills-reports", "SKILLS"],
-                    ["/team-skills-reports", "TEAM SKILLS"],
-                  ], 
-                  true)
-                }
+                {createListJsx(reportsLinks, true)}
             </Collapse>
             {createLinkJsx("/edit-skills", "SKILLS", false)}
           </List>
@@ -259,7 +256,8 @@ function Menu() {
         >
 
           <Avatar
-            onClick={() => history.push(`/profile/${id}`)}
+            component={Link}
+            to={`/profile/${id}`}
             src={getAvatarURL(workEmail)}
             style={{
               position: "absolute",

--- a/web-ui/src/components/menu/__snapshots__/Menu.test.js.snap
+++ b/web-ui/src/components/menu/__snapshots__/Menu.test.js.snap
@@ -54,8 +54,9 @@ exports[`<Menu /> renders correctly 1`] = `
       aria-haspopup="true"
       onClick={[Function]}
     >
-      <div
+      <a
         className="MuiAvatar-root MuiAvatar-circle"
+        href="/profile/undefined"
         onClick={[Function]}
         style={
           Object {
@@ -71,7 +72,7 @@ exports[`<Menu /> renders correctly 1`] = `
           className="MuiAvatar-img"
           src="http://localhost:8080/services/member-profiles/member-photos/test%40tester.com"
         />
-      </div>
+      </a>
     </div>
   </header>
   <nav
@@ -143,9 +144,10 @@ exports[`<Menu /> renders correctly 1`] = `
             <nav
               className="MuiList-root makeStyles-listStyle-9 MuiList-padding"
             >
-              <div
+              <a
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 MuiListItem-gutters MuiListItem-button"
+                href="/home"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -170,10 +172,11 @@ exports[`<Menu /> renders correctly 1`] = `
                     HOME
                   </span>
                 </div>
-              </div>
-              <div
+              </a>
+              <a
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 MuiListItem-gutters MuiListItem-button"
+                href="/checkins"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -198,7 +201,7 @@ exports[`<Menu /> renders correctly 1`] = `
                     CHECK-INS
                   </span>
                 </div>
-              </div>
+              </a>
             </nav>
             <button
               className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeLarge MuiButton-sizeLarge"
@@ -247,9 +250,10 @@ exports[`<Menu /> renders correctly 1`] = `
                   <nav
                     className="MuiList-root makeStyles-listStyle-9"
                   >
-                    <div
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button Mui-selected"
+                      href="/guilds"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -274,10 +278,11 @@ exports[`<Menu /> renders correctly 1`] = `
                           GUILDS
                         </span>
                       </div>
-                    </div>
-                    <div
+                    </a>
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button"
+                      href="/people"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -302,10 +307,11 @@ exports[`<Menu /> renders correctly 1`] = `
                           PEOPLE
                         </span>
                       </div>
-                    </div>
-                    <div
+                    </a>
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button"
+                      href="/teams"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -330,7 +336,7 @@ exports[`<Menu /> renders correctly 1`] = `
                           TEAMS
                         </span>
                       </div>
-                    </div>
+                    </a>
                   </nav>
                 </div>
               </div>
@@ -375,9 +381,10 @@ exports[`<Menu /> renders correctly 1`] = `
             <nav
               className="MuiList-root makeStyles-listStyle-9 MuiList-padding"
             >
-              <div
+              <a
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 MuiListItem-gutters MuiListItem-button"
+                href="/home"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -402,10 +409,11 @@ exports[`<Menu /> renders correctly 1`] = `
                     HOME
                   </span>
                 </div>
-              </div>
-              <div
+              </a>
+              <a
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 MuiListItem-gutters MuiListItem-button"
+                href="/checkins"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -430,7 +438,7 @@ exports[`<Menu /> renders correctly 1`] = `
                     CHECK-INS
                   </span>
                 </div>
-              </div>
+              </a>
             </nav>
             <button
               className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeLarge MuiButton-sizeLarge"
@@ -479,9 +487,10 @@ exports[`<Menu /> renders correctly 1`] = `
                   <nav
                     className="MuiList-root makeStyles-listStyle-9"
                   >
-                    <div
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button Mui-selected"
+                      href="/guilds"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -506,10 +515,11 @@ exports[`<Menu /> renders correctly 1`] = `
                           GUILDS
                         </span>
                       </div>
-                    </div>
-                    <div
+                    </a>
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button"
+                      href="/people"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -534,10 +544,11 @@ exports[`<Menu /> renders correctly 1`] = `
                           PEOPLE
                         </span>
                       </div>
-                    </div>
-                    <div
+                    </a>
+                    <a
                       aria-disabled={false}
                       className="MuiButtonBase-root MuiListItem-root makeStyles-listItem-10 makeStyles-nested-7 MuiListItem-gutters MuiListItem-button"
+                      href="/teams"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onDragLeave={[Function]}
@@ -562,7 +573,7 @@ exports[`<Menu /> renders correctly 1`] = `
                           TEAMS
                         </span>
                       </div>
-                    </div>
+                    </a>
                   </nav>
                 </div>
               </div>


### PR DESCRIPTION
Forgot to update the snapshot tests (whoops) so I closed the initial PR .  Now all changes from earlier (summary below) are included and I also updated the snapshot tests.

The function I made initially to check whether a collapsible list should be open was hardcoded, so it didn't check for the newly added 'TEAM SKILLS' link. I rewrote it so that it is no longer hard coded. I also noticed that links weren't being rendered to the DOM with the `<a>` tag. To fix this I used the Material UI component prop and passed the react-router-dom link component (https://material-ui.com/guides/composition/#link).