### PR TITLE
add Dialog component to GuildSummaryCard and disable delete for both …

### DIFF
--- a/web-ui/src/components/guild-results/GuildSummaryCard.jsx
+++ b/web-ui/src/components/guild-results/GuildSummaryCard.jsx
@@ -4,7 +4,18 @@ import {AppContext} from "../../context/AppContext";
 import {UPDATE_GUILDS, UPDATE_TOAST} from "../../context/actions";
 import EditGuildModal from "./EditGuildModal";
 
-import {Card, CardActions, CardContent, CardHeader} from "@material-ui/core";
+import {
+    Card, 
+    CardActions, 
+    CardContent, 
+    CardHeader, 
+    Dialog, 
+    DialogContentText, 
+    DialogTitle, 
+    DialogContent, 
+    DialogActions, 
+    Button
+} from "@material-ui/core";
 import PropTypes from "prop-types";
 import {deleteGuild, updateGuild} from "../../api/guild.js";
 import SplitButton from "../split-button/SplitButton";
@@ -42,6 +53,7 @@ const GuildSummaryCard = ({guild, index}) => {
     const {state, dispatch} = useContext(AppContext);
     const {guilds, userProfile, csrf} = state;
     const [open, setOpen] = useState(false);
+    const [openDelete, setOpenDelete] = useState(false);
     const isAdmin =
         userProfile && userProfile.role && userProfile.role.includes("ADMIN");
 
@@ -60,8 +72,10 @@ const GuildSummaryCard = ({guild, index}) => {
             : leads.some((lead) => lead.memberId === userProfile.memberProfile.id);
 
     const handleOpen = () => setOpen(true);
-
     const handleClose = () => setOpen(false);
+
+    const handleOpenDeleteConfirmation = () => setOpenDelete(true);
+    const handleCloseDeleteConfirmation = () => setOpenDelete(false);
 
     const deleteAGuild = async (id) => {
         if (id && csrf) {
@@ -88,8 +102,13 @@ const GuildSummaryCard = ({guild, index}) => {
     const options =
         isAdmin || isGuildLead ? ["Edit Guild", "Delete Guild"] : ["Edit Guild"];
 
-    const handleAction = (e, index) =>
-        index === 0 ? handleOpen() : deleteAGuild(guild.id);
+    const handleAction = (e, index) => {
+        if (index === 0) {
+            handleOpen();
+        } else if (index === 1) {
+            handleOpenDeleteConfirmation();
+        }
+    };
 
     return (
         <Card className={classes.card}>
@@ -99,7 +118,6 @@ const GuildSummaryCard = ({guild, index}) => {
               subheader: classes.title,
             }} title={guild.name} subheader={guild.description}/>
             <CardContent>
-
                 {guild.guildMembers == null ? (
                     <React.Fragment>
                     <strong>Guild Leads: </strong>None Assigned
@@ -122,10 +140,34 @@ const GuildSummaryCard = ({guild, index}) => {
                     </React.Fragment>
 
                 )}
-
             </CardContent>
             <CardActions>
-                {(isAdmin || isGuildLead) && <SplitButton options={options} onClick={handleAction}/>}
+                {(isAdmin || isGuildLead) && (
+                <>
+                    <SplitButton options={options} onClick={handleAction} />
+                    <Dialog
+                    open={openDelete}
+                    onClose={handleCloseDeleteConfirmation}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                    >
+                        <DialogTitle id="alert-dialog-title">Delete guild?</DialogTitle>
+                        <DialogContent>
+                            <DialogContentText id="alert-dialog-description">
+                            Are you sure you want to delete the guild?
+                            </DialogContentText>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={handleCloseDeleteConfirmation} color="primary">
+                            Cancel
+                            </Button>
+                            <Button disabled onClick={deleteAGuild} color="primary" autoFocus>
+                            Yes
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+                </>
+                )}
             </CardActions>
             <EditGuildModal
                 guild={guild}

--- a/web-ui/src/components/team-results/TeamSummaryCard.jsx
+++ b/web-ui/src/components/team-results/TeamSummaryCard.jsx
@@ -147,7 +147,7 @@ const TeamSummaryCard = ({ team, index }) => {
       </CardContent>
       <CardActions>
         {(isAdmin || isTeamLead) && (
-          <div>
+          <>
             <SplitButton options={options} onClick={handleAction} />
             <Dialog
               open={openDelete}
@@ -165,12 +165,12 @@ const TeamSummaryCard = ({ team, index }) => {
                 <Button onClick={handleCloseDeleteConfirmation} color="primary">
                   Cancel
                 </Button>
-                <Button onClick={deleteATeam} color="primary" autoFocus>
+                <Button disabled onClick={deleteATeam} color="primary" autoFocus>
                   Yes
                 </Button>
               </DialogActions>
             </Dialog>
-          </div>
+          </>
         )}
       </CardActions>
       <EditTeamModal

--- a/web-ui/src/components/team-results/__snapshots__/TeamResults.test.js.snap
+++ b/web-ui/src/components/team-results/__snapshots__/TeamResults.test.js.snap
@@ -118,72 +118,70 @@ exports[`renders correctly 1`] = `
         className="MuiCardActions-root MuiCardActions-spacing"
       >
         <div>
-          <div>
-            <div
-              aria-label="split button"
-              className="MuiButtonGroup-root MuiButtonGroup-contained"
-              role="group"
+          <div
+            aria-label="split button"
+            className="MuiButtonGroup-root MuiButtonGroup-contained"
+            role="group"
+          >
+            <button
+              className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
             >
-              <button
-                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
+              <span
+                className="MuiButton-label"
               >
-                <span
-                  className="MuiButton-label"
-                >
-                  Edit Team
-                </span>
-              </button>
-              <button
-                aria-haspopup="menu"
-                aria-label="select merge strategy"
-                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
+                Edit Team
+              </span>
+            </button>
+            <button
+              aria-haspopup="menu"
+              aria-label="select merge strategy"
+              className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                className="MuiButton-label"
               >
-                <span
-                  className="MuiButton-label"
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M7 10l5 5 5-5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
       </div>
@@ -226,72 +224,70 @@ exports[`renders correctly 1`] = `
         className="MuiCardActions-root MuiCardActions-spacing"
       >
         <div>
-          <div>
-            <div
-              aria-label="split button"
-              className="MuiButtonGroup-root MuiButtonGroup-contained"
-              role="group"
+          <div
+            aria-label="split button"
+            className="MuiButtonGroup-root MuiButtonGroup-contained"
+            role="group"
+          >
+            <button
+              className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
             >
-              <button
-                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
+              <span
+                className="MuiButton-label"
               >
-                <span
-                  className="MuiButton-label"
-                >
-                  Edit Team
-                </span>
-              </button>
-              <button
-                aria-haspopup="menu"
-                aria-label="select merge strategy"
-                className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
+                Edit Team
+              </span>
+            </button>
+            <button
+              aria-haspopup="menu"
+              aria-label="select merge strategy"
+              className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                className="MuiButton-label"
               >
-                <span
-                  className="MuiButton-label"
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M7 10l5 5 5-5z"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
+                  <path
+                    d="M7 10l5 5 5-5z"
+                  />
+                </svg>
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/web-ui/src/components/team-results/__snapshots__/TeamSummaryCard.test.js.snap
+++ b/web-ui/src/components/team-results/__snapshots__/TeamSummaryCard.test.js.snap
@@ -80,78 +80,76 @@ exports[`renders correctly for ADMIN 1`] = `
     className="MuiCardActions-root MuiCardActions-spacing"
   >
     <div>
-      <div>
-        <div
-          aria-label="split button"
-          className="MuiButtonGroup-root MuiButtonGroup-contained"
-          role="group"
+      <div
+        aria-label="split button"
+        className="MuiButtonGroup-root MuiButtonGroup-contained"
+        role="group"
+      >
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
         >
-          <button
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
+          <span
+            className="MuiButton-label"
           >
-            <span
-              className="MuiButton-label"
-            >
-              Edit Team
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </button>
-          <button
-            aria-haspopup="menu"
-            aria-label="select merge strategy"
-            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
+            Edit Team
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          aria-haspopup="menu"
+          aria-label="select merge strategy"
+          className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="MuiButton-label"
           >
-            <span
-              className="MuiButton-label"
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7 10l5 5 5-5z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </button>
-        </div>
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
…Dialogs

The teams page has a dialog popup when you press delete on a team that asks if you're sure that you want to delete the team and the guilds page does not. I went ahead and added  a confirmation dialog into the guilds page and then disabled each button from there. 