### PR TITLE
add an interceptor to the axios instance to catch 401 errors

### DIFF
--- a/web-ui/src/api/api.js
+++ b/web-ui/src/api/api.js
@@ -18,6 +18,23 @@ export const getMyAxios = async () => {
       baseURL: BASE_API_URL,
       withCredentials: true,
     });
+
+    myAxios.interceptors.response.use(
+      // Any status code that lie within the range of 2xx cause this function to trigger
+      (res) => {
+        return res;
+      }, 
+      // Any status codes that falls outside the range of 2xx cause this function to trigger
+      (err) => {
+        if (401 === err.response.status){
+          // create a message for 401 error so that the Toast is updated properly
+          err.response.data = {
+            message: "Your session has expired.  Please refresh the page to start a new session."
+          };
+        }
+        return Promise.reject(err);
+      }
+    )
   }
   return myAxios;
 };


### PR DESCRIPTION
This fixes the application timeout error and informs the user of their need to re-sign in when their session expires.

I didn't end up creating a popup warning for the user as they near the end of their session because the JWT is an Http only cookie and so I couldn't access its time limit.  However, the user will now get a Toast informing them of their session expiration and the need to re-signin whenever they make a request using an expired JWT.  Once refresh tokens are created on the back-end we can refactor the code to request a new JWT instead of throwing an error. 