### PR TITLE
Feature 1166/support markdown in notes

### DIFF
--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -53,6 +53,7 @@
     "react-jss": "^10.4.0",
     "react-modal": "^3.11.2",
     "react-pdf": "^5.0.0-beta.4",
+    "react-quill": "^1.3.5",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.0",
     "react-test-renderer": "^16.13.1",

--- a/web-ui/src/components/markdown-note/MarkdownNote.jsx
+++ b/web-ui/src/components/markdown-note/MarkdownNote.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ReactQuill from 'react-quill'
+import 'react-quill/dist/quill.snow.css';
+const modules = {
+  toolbar: [
+    [{ 'header': [1, 2, false] }],
+    ['bold', 'italic', 'underline','strike', 'blockquote'],
+    [{'list': 'ordered'}, {'list': 'bullet'}, {'indent': '-1'}, {'indent': '+1'}],
+    ['link'],
+    ['clean'],
+  ],
+}
+
+const formats = [
+  'header',
+  'bold', 'italic', 'underline', 'strike', 'blockquote',
+  'list', 'bullet', 'indent',
+  'link',
+]
+
+export default function MarkdownNote(props) {
+  return (
+    <ReactQuill 
+      {...props}  
+      theme="snow"
+      modules={modules}
+      formats={formats}>
+    </ReactQuill>
+  )
+}

--- a/web-ui/src/components/markdown-note/MarkdownNote.stories.js
+++ b/web-ui/src/components/markdown-note/MarkdownNote.stories.js
@@ -1,0 +1,30 @@
+import React, {useRef} from 'react';
+import MarkdownNote from './MarkdownNote';
+
+
+export default {
+  component: MarkdownNote,
+  title: 'Check Ins/MarkdownNote',
+}
+
+const Template = (args) => {
+  return <MarkdownNote {...args} />;
+}
+
+
+export const NoPropsPassed = Template.bind({});
+
+export const ControlledComponent = Template.bind({});
+ControlledComponent.args = {
+  value: "<h1>Controlled Component</h1><p>Can pass in a value and onChange prop to make the component controlled</p>",
+  onChange: () => {console.log('handle change')}
+}
+
+export const CustomStyling = Template.bind({});
+CustomStyling.args = {
+  value: "<h1>Configure the component with a style prop.</h1><h1>Here we pass in a defined height.</h1><h1>This sets the overflow to auto for the text area.</h1><h1>overflow</h1><h1>overflow</h1><h1>overflow</h1>",
+  style: {height: "175px"},
+}
+
+
+

--- a/web-ui/src/components/markdown-note/MarkdownNote.stories.js
+++ b/web-ui/src/components/markdown-note/MarkdownNote.stories.js
@@ -26,5 +26,11 @@ CustomStyling.args = {
   style: {height: "175px"},
 }
 
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  readOnly: true,
+  defaultValue: "<h1>Cannot edit</h1>"
+}
+
 
 

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -128,13 +128,3 @@ const Notes = (props) => {
 };
 
 export default Notes;
-
-
-{/* <textarea
-disabled={
-  currentCheckin?.completed ||
-  note === undefined || Object.keys(note) === 0
-}
-onChange={handleNoteChange}
-value={note && note.description ? note.description : ""}
-/> */}

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -13,7 +13,7 @@ import Skeleton from "@material-ui/lab/Skeleton";
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
-
+import MarkdownNote from "../markdown-note/MarkdownNote";
 import "./Note.css";
 
 async function realUpdate(note, csrf) {
@@ -85,44 +85,67 @@ const Notes = (props) => {
     }
   }, [csrf, checkinId, currentUserId, pdlId]);
 
-  const handleNoteChange = (e) => {
+  // const handleNoteChange = (e) => {
+  //   if (Object.keys(note).length === 0 || !csrf) {
+  //     return;
+  //   }
+  //   const { value } = e.target;
+  //   setNote((note) => {
+  //     const newNote = { ...note, description: value };
+  //     updateNote(newNote, csrf);
+  //     return newNote;
+  //   });
+  // };
+  const handleNoteChange = (content, delta, source, editor) => {
     if (Object.keys(note).length === 0 || !csrf) {
       return;
     }
-    const { value } = e.target;
+    
     setNote((note) => {
-      const newNote = { ...note, description: value };
+      const newNote = { ...note, description: content };
       updateNote(newNote, csrf);
       return newNote;
     });
-  };
+  }
 
   return (
       <Card className="note">
         <CardHeader avatar={<NotesIcon />} title={`Notes for ${currentMember?.name}`} titleTypographyProps={{variant: "h5", component: "h2"}} />
         <CardContent>
-          <div className="container">
             {isLoading ? (
-              <div className="skeleton">
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
+              <div className="container">
+                <div className="skeleton">
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                </div>
               </div>
             ) : (
-              <textarea
-                disabled={
+              <MarkdownNote 
+                style={{height: "175px", marginBottom: "30px"}}
+                value={note && note.description ? note.description : ""}
+                onChange={handleNoteChange}
+                readOnly={
                   currentCheckin?.completed ||
                   note === undefined || Object.keys(note) === 0
                 }
-                onChange={handleNoteChange}
-                value={note && note.description ? note.description : ""}
               />
             )}
-          </div>
+          
         </CardContent>
       </Card>
       );
 };
 
 export default Notes;
+
+
+{/* <textarea
+disabled={
+  currentCheckin?.completed ||
+  note === undefined || Object.keys(note) === 0
+}
+onChange={handleNoteChange}
+value={note && note.description ? note.description : ""}
+/> */}

--- a/web-ui/src/components/notes/Note.jsx
+++ b/web-ui/src/components/notes/Note.jsx
@@ -85,17 +85,6 @@ const Notes = (props) => {
     }
   }, [csrf, checkinId, currentUserId, pdlId]);
 
-  // const handleNoteChange = (e) => {
-  //   if (Object.keys(note).length === 0 || !csrf) {
-  //     return;
-  //   }
-  //   const { value } = e.target;
-  //   setNote((note) => {
-  //     const newNote = { ...note, description: value };
-  //     updateNote(newNote, csrf);
-  //     return newNote;
-  //   });
-  // };
   const handleNoteChange = (content, delta, source, editor) => {
     if (Object.keys(note).length === 0 || !csrf) {
       return;

--- a/web-ui/src/components/private-note/PrivateNote.jsx
+++ b/web-ui/src/components/private-note/PrivateNote.jsx
@@ -15,6 +15,7 @@ import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 
 import "./PrivateNote.css";
+import MarkdownNote from "../markdown-note/MarkdownNote";
 
 async function realUpdate(note, csrf) {
   await updatePrivateNote(note, csrf);
@@ -89,41 +90,43 @@ const PrivateNote = () => {
     }
   }, [csrf, checkinId, currentUserId, pdlId]);
 
-  const handleNoteChange = (e) => {
+  const handleNoteChange = (content, delta, source, editor) => {
     if (Object.keys(note).length === 0 || !csrf) {
       return;
     }
-    const { value } = e.target;
+    
     setNote((note) => {
-      const newNote = { ...note, description: value };
+      const newNote = { ...note, description: content };
       updateNote(newNote, csrf);
       return newNote;
     });
-  };
+  }
 
   return canView && (
       <Card className="private-note">
         <CardHeader avatar={<LockIcon />} title="Private Notes" titleTypographyProps={{variant: "h5", component: "h2"}} />
         <CardContent>
-          <div className="container">
             {isLoading ? (
-              <div className="skeleton">
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
-                <Skeleton variant="text" height={"2rem"} />
+              <div className="container">
+                <div className="skeleton">
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                  <Skeleton variant="text" height={"2rem"} />
+                </div>
               </div>
             ) : (
-              <textarea
-                disabled={
+              <MarkdownNote 
+                style={{height: "175px", marginBottom: "30px"}}
+                value={note && note.description ? note.description : ""}
+                onChange={handleNoteChange}
+                readOnly={
                   currentCheckin?.completed ||
                   note === undefined || Object.keys(note) === 0
                 }
-                onChange={handleNoteChange}
-                value={note && note.description ? note.description : ""}
               />
             )}
-          </div>
+          
         </CardContent>
       </Card>
       );

--- a/web-ui/yarn.lock
+++ b/web-ui/yarn.lock
@@ -2972,6 +2972,13 @@
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz"
   integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
 
+"@types/quill@1.3.10":
+  version "1.3.10"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.10.tgz#dc1f7b6587f7ee94bdf5291bc92289f6f0497613"
+  integrity sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==
+  dependencies:
+    parchment "^1.1.2"
+
 "@types/reach__router@^1.3.7":
   version "1.3.7"
   resolved "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.7.tgz"
@@ -5129,6 +5136,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clone@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clsx@^1.0.2, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
@@ -5507,6 +5519,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.0:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
+  integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 create-react-context@0.3.0, create-react-context@^0.3.0:
   version "0.3.0"
@@ -7007,6 +7027,11 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=
+
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
@@ -7143,7 +7168,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -7180,6 +7205,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
+  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
 
 fast-glob@^2.0.2, fast-glob@^2.2.6:
   version "2.2.7"
@@ -10258,6 +10288,11 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.4:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loglevel@^1.6.8:
   version "1.7.1"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz"
@@ -11392,6 +11427,11 @@ param-case@^3.0.3:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+parchment@^1.1.2, parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+  integrity sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -12640,6 +12680,27 @@ querystringify@^2.1.1:
   resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
+quill-delta@^3.6.2:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.3.tgz#b19fd2b89412301c60e1ff213d8d860eac0f1032"
+  integrity sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.2"
+    fast-diff "1.1.2"
+
+quill@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
+  integrity sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.2"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
+
 raf-schd@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz"
@@ -12827,6 +12888,11 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
+react-dom-factories@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
+  integrity sha1-63cFxNs2+1AbOqOP91lhaqD/luA=
+
 react-dom@^16.13.1:
   version "16.14.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz"
@@ -12989,6 +13055,18 @@ react-popper@^2.2.4:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-quill@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/react-quill/-/react-quill-1.3.5.tgz#8c4ad759da03365b17c79c6c52afa9772259844e"
+  integrity sha512-/W/rNCW+6QpGz8yQ9tFK5Ka/h/No1RqrcOOvCIOR092OiKzRFlU2xbPEwiP3Wgy/Dx13pi1YhjReDMX/5uotJg==
+  dependencies:
+    "@types/quill" "1.3.10"
+    create-react-class "^15.6.0"
+    lodash "^4.17.4"
+    prop-types "^15.5.10"
+    quill "^1.3.7"
+    react-dom-factories "^1.0.0"
 
 react-redux@^7.1.1:
   version "7.2.2"


### PR DESCRIPTION
I added the ReactQuill dependency which is a React component built around Quill.js.  It is an WYSIWYG editor that will allow for better formatting when writing notes.  ReactQuill is MIT licensed and Quill.js has the BSD 3-Clause "New" or "Revised" License.  Both allow for private and commercial use. 

To test it out, create a new check-in and include some notes.  The component is also in storybook.  