### PR TITLE
Feature 1246/connect template backend to template selection frontend with api

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -393,6 +393,36 @@ INSERT INTO feedback_templates
 VALUES
 ('18ef2032-c264-411e-a8e1-ddda9a714bae', '6207b3fd-042d-49aa-9e28-dcc04f537c2d', 'Q1 Feedback', 'Get feedback for quarter 1', '2021-06-06', null, null);
 
+INSERT INTO template_questions
+(id, question, template_id, question_number)
+VALUES
+('d6d05f53-682c-4c37-be32-8aab5f89767f', 'What are this team member''s top strengths (include examples where possible)?', '18ef2032-c264-411e-a8e1-ddda9a714bae', 1);
+
+INSERT INTO template_questions
+(id, question, template_id, question_number)
+VALUES
+('47f997ca-0045-4147-afcb-0c9ed0b44978', 'In what ways are this team member''s contributions impacting the objectives of the organization, their project, or their team?', '18ef2032-c264-411e-a8e1-ddda9a714bae', 2);
+
+INSERT INTO feedback_templates
+(id, creator_id, title, description, date_created, updater_id, date_updated)
+VALUES
+('97b0a312-e5dd-46f4-a600-d8be2ad925bb', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9', 'Survey 1', 'Make a survey with a few questions', '2021-05-05', null, null);
+
+INSERT INTO template_questions
+(id, question, template_id, question_number)
+VALUES
+('89c8b612-fca8-4144-88cd-176ddfca35ad', 'What can this team member improve on that would help them increase their effectiveness (include examples where possible)?', '97b0a312-e5dd-46f4-a600-d8be2ad925bb', 1);
+
+INSERT INTO template_questions
+(id, question, template_id, question_number)
+VALUES
+('afa7e2cb-366a-4c16-a205-c0d493b80d85', 'In what ways does this team member represent OCI''s values?', '97b0a312-e5dd-46f4-a600-d8be2ad925bb', 2);
+
+INSERT INTO feedback_templates
+(id, creator_id, title, description, date_created, updater_id, date_updated)
+VALUES
+('2cb80a06-e723-482f-af9b-6b9516cabfcd', '2559a257-ae84-4076-9ed4-3820c427beeb', 'Sample Template', 'This template does not have any questions on it', '2021-04-04', null, null);
+
 INSERT INTO feedback_requests
 (id, creator_id, requestee_id, recipient_id, send_date, due_date, submit_date, status)
 VALUES

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -93,6 +93,7 @@
     "@storybook/react": "^6.0.21",
     "babel-loader": "8.1.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
+    "prop-types": "^15.7.2",
     "react-is": "^16.13.1",
     "react-testing-library": "^8.0.1"
   },

--- a/web-ui/src/api/feedbacktemplate.js
+++ b/web-ui/src/api/feedbacktemplate.js
@@ -13,6 +13,34 @@ export const createFeedbackTemplate = async (feedbackTemplate, cookie) => {
   });
 };
 
+export const createFeedbackTemplateWithQuestion = async (template, question, cookie) => {
+
+  const templateReq = resolve({
+    method: "post",
+    url: feedbackTemplateUrl,
+    responseType: "json",
+    data: template,
+    headers: { "X-CSRF-Header": cookie }
+  });
+
+  const questionReq = templateReq.then((templateRes) => {
+    if (!templateRes.error && templateRes.payload && templateRes.payload.data) {
+      question.templateId = templateRes.payload.data.id;
+      return resolve({
+        method: "post",
+        url: templateQuestionsUrl,
+        responseType: "json",
+        data: question,
+        headers: {"X-CSRF-Header": cookie}
+      });
+    }
+  });
+
+  return Promise.all([templateReq, questionReq]).then(([templateRes, questionRes]) => {
+    return {templateRes, questionRes};
+  });
+}
+
 export const createTemplateQuestions = async (questions, cookie) => {
   const questionReqs = [];
   questions.forEach((question) => {
@@ -87,5 +115,5 @@ export const getAllFeedbackTemplates = async (cookie) => {
     url: feedbackTemplateUrl,
     responseType: "json",
     headers: { "X-CSRF-Header": cookie },
-  })
+  });
 }

--- a/web-ui/src/components/feedback_template_selector/FeedbackTemplateSelector.jsx
+++ b/web-ui/src/components/feedback_template_selector/FeedbackTemplateSelector.jsx
@@ -15,30 +15,6 @@ import {selectCsrfToken, selectCurrentUser} from "../../context/selectors";
 import "./FeedbackTemplateSelector.css";
 import {Search} from "@material-ui/icons";
 
-const allTemplates = [
-  {
-    id: 123,
-    title: "Survey 1",
-    description: "Make a survey with a few questions",
-    creatorId: "01b7d769-9fa2-43ff-95c7-f3b950a27bf9",
-    questions: []
-  },
-  {
-    id: 124,
-    title: "Feedback Survey 2",
-    description: "Another type of survey",
-    creatorId: "2559a257-ae84-4076-9ed4-3820c427beeb",
-    questions: [],
-  },
-  {
-    id: 125,
-    title: "Custom Template",
-    description: "A very very very very very very very very very very very very very very very very very very very very very very very very very very long description",
-    creatorId: "802cb1f5-a255-4236-8719-773fa53d79d9",
-    questions: []
-  },
-];
-
 const propTypes = {
   query: PropTypes.string,
   changeQuery: PropTypes.func
@@ -70,7 +46,7 @@ const propTypes = {
           : null
       if (templateList) {
         templatesFetched.current = true;
-        return [...templateList, ...allTemplates];
+        return templateList;
       }
      }
     if (csrf && currentUserId) {

--- a/web-ui/src/components/template-card/TemplateCard.js
+++ b/web-ui/src/components/template-card/TemplateCard.js
@@ -14,15 +14,6 @@ import {AppContext} from "../../context/AppContext";
 import {selectCsrfToken} from "../../context/selectors";
 import {getMember} from "../../api/member";
 
-const propTypes = {
-    title: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    createdBy: PropTypes.string.isRequired,
-    isAdHoc: PropTypes.bool,
-    onPreviewClick: PropTypes.func,
-    onCardClick: PropTypes.func
-}
-
 const cutText = (text, maxCharacters) => {
     if (!text) {
         text = "";
@@ -67,6 +58,15 @@ const TemplateCardHeader = withStyles(templateCardHeaderStyles, {
     </div>
 ));
 
+const propTypes = {
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    creatorId: PropTypes.string.isRequired,
+    isAdHoc: PropTypes.bool,
+    onPreviewClick: PropTypes.func,
+    onCardClick: PropTypes.func
+}
+
 const TemplateCard = (props) => {
 
     const { state } = useContext(AppContext);
@@ -82,8 +82,8 @@ const TemplateCard = (props) => {
     // Get name of the template creator
     useEffect(() => {
         async function getCreatorName() {
-            if (props.createdBy) {
-                let res = await getMember(props.createdBy, csrf);
+            if (props.creatorId) {
+                let res = await getMember(props.creatorId, csrf);
                 let creatorProfile =
                   res.payload && res.payload.data && !res.error
                     ? res.payload.data
@@ -94,7 +94,7 @@ const TemplateCard = (props) => {
         if (csrf) {
             getCreatorName();
         }
-    }, [props.createdBy, csrf]);
+    }, [props.creatorId, csrf]);
 
     return (
         <Card onClick={props.onCardClick} className='feedback-template-card'>

--- a/web-ui/src/components/template-preview-modal/TemplatePreviewModal.jsx
+++ b/web-ui/src/components/template-preview-modal/TemplatePreviewModal.jsx
@@ -7,13 +7,14 @@ import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import Slide from '@material-ui/core/Slide';
-import {TextField} from "@material-ui/core";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Divider from "@material-ui/core/Divider";
 import Button from "@material-ui/core/Button"
 import "./TemplatePreviewModal.css";
+import AdHocCreationForm from "./ad_hoc_creation_form/AdHocCreationForm";
+import PropTypes from "prop-types";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -42,31 +43,28 @@ const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const TemplatePreviewModal = ({ open, onSubmit, onClose, template }) => {
+const propTypes = {
+  open: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func,
+  onClose: PropTypes.func,
+  template: PropTypes.object,
+  createAdHoc: PropTypes.bool
+}
+
+const TemplatePreviewModal = ({ open, onSubmit, onClose, template, createAdHoc }) => {
 
   const classes = useStyles();
 
-  const [adHocTitle, setAdHocTitle] = useState(template?.title);
-  const [adHocDescription, setAdHocDescription] = useState(template?.description);
+  const [newAdHocData, setNewAdHocData] = useState({});
 
   const submitPreview = () => {
-    if (!template) {
-      return;
-    }
-
     const submittedTemplate = {...template};
-    if (template.isAdHoc) {
-      submittedTemplate.title = adHocTitle;
-      submittedTemplate.description = adHocDescription;
+    if (createAdHoc) {
+      submittedTemplate.title = newAdHocData.title;
+      submittedTemplate.description = newAdHocData.description;
     }
     onSubmit(submittedTemplate);
-    setAdHocTitle(template?.title);
-    setAdHocDescription(template?.description);
   };
-
-  if (!template) {
-    return null;
-  }
 
   return (
     <Dialog fullScreen open={open} onClose={onClose} TransitionComponent={Transition}>
@@ -87,55 +85,27 @@ const TemplatePreviewModal = ({ open, onSubmit, onClose, template }) => {
       </AppBar>
 
       <div className="preview-modal-content">
-      {template.isAdHoc && !template.id ?
+      {createAdHoc ?
+        <AdHocCreationForm onFormChange={(form) => setNewAdHocData(form)}/> :
         <React.Fragment>
-          <TextField
-            label="Title"
-            placeholder="Ad Hoc"
-            fullWidth
-            margin="normal"
-            value={adHocTitle}
-            onChange={(event) => {
-              setAdHocTitle(event.target.value)
-            }}/>
-          <TextField
-            label="Description"
-            placeholder="Ask a single question"
-            fullWidth
-            margin="normal"
-            value={adHocDescription}
-            onChange={(event) => {
-              setAdHocDescription(event.target.value)
-
-            }}/>
+          <Typography>{template.description}</Typography>
+          <List>
+            {template.questions && template.questions.map((question, index) => (
+              <React.Fragment>
+                <ListItem button>
+                  <ListItemText primary={`Question ${index + 1}`} secondary={question}/>
+                </ListItem>
+                <Divider/>
+              </React.Fragment>
+            ))}
+          </List>
         </React.Fragment>
-        :
-        <Typography>{template.description}</Typography>
-      }
-
-      {template.isAdHoc && !template.id ?
-        <TextField
-          label="Ask a feedback question"
-          placeholder="How is your day going?"
-          fullWidth
-          multiline
-          rowsMax={10}
-          margin="normal"/>
-        :
-        <List>
-          {template.questions && template.questions.map((question, index) => (
-            <React.Fragment>
-              <ListItem button>
-                <ListItemText primary={`Question ${index + 1}`} secondary={question}/>
-              </ListItem>
-              <Divider/>
-            </React.Fragment>
-          ))}
-        </List>
       }
       </div>
     </Dialog>
   );
 }
+
+TemplatePreviewModal.propTypes = propTypes;
 
 export default TemplatePreviewModal;

--- a/web-ui/src/components/template-preview-modal/TemplatePreviewModal.jsx
+++ b/web-ui/src/components/template-preview-modal/TemplatePreviewModal.jsx
@@ -101,11 +101,13 @@ const TemplatePreviewModal = ({ open, onSubmit, onClose, template, createAdHoc }
 
   const submitPreview = () => {
     const submittedTemplate = {...template};
+    let submittedQuestion = null;
     if (createAdHoc) {
       submittedTemplate.title = newAdHocData.title;
       submittedTemplate.description = newAdHocData.description;
+      submittedQuestion = newAdHocData.question;
     }
-    onSubmit(submittedTemplate);
+    onSubmit(submittedTemplate, submittedQuestion);
   };
 
   return (
@@ -140,7 +142,7 @@ const TemplatePreviewModal = ({ open, onSubmit, onClose, template, createAdHoc }
             </Typography>
           }
           <List>
-            {templateQuestions && templateQuestions.map((templateQuestion, index) => (
+            {templateQuestions && templateQuestions.map((templateQuestion) => (
               <ListItem
                 className={classes.questionListItem}
                 key={templateQuestion?.id}

--- a/web-ui/src/components/template-preview-modal/ad_hoc_creation_form/AdHocCreationForm.jsx
+++ b/web-ui/src/components/template-preview-modal/ad_hoc_creation_form/AdHocCreationForm.jsx
@@ -1,0 +1,60 @@
+import React, {useEffect, useState} from "react";
+import {TextField} from "@material-ui/core";
+import PropTypes from "prop-types";
+
+const propTypes = {
+  onFormChange: PropTypes.func
+}
+
+const AdHocCreationForm = (props) => {
+
+  const [title, setTitle] = useState("Ad Hoc");
+  const [description, setDescription] = useState("");
+  const [question, setQuestion] = useState("");
+
+  useEffect(() => {
+    props.onFormChange({
+      title: title,
+      description: description,
+      question: question
+    }); // eslint-disable-next-line
+  }, [title, description, question]);
+
+  return (
+    <React.Fragment>
+      <TextField
+        label="Title"
+        placeholder="Ad Hoc"
+        fullWidth
+        margin="normal"
+        value={title}
+        onChange={(event) => {
+          setTitle(event.target.value);
+        }}/>
+      <TextField
+        label="Description"
+        placeholder="Ask a single question"
+        fullWidth
+        margin="normal"
+        value={description}
+        onChange={(event) => {
+          setDescription(event.target.value);
+        }}/>
+      <TextField
+        label="Ask a feedback question"
+        placeholder="How is your day going?"
+        fullWidth
+        multiline
+        rowsMax={10}
+        margin="normal"
+        value={question}
+        onChange={(event) => {
+          setQuestion(event.target.value);
+        }}/>
+    </React.Fragment>
+  );
+}
+
+AdHocCreationForm.propTypes = propTypes;
+
+export default AdHocCreationForm;


### PR DESCRIPTION
Closes #1246 

To test this, go to `/feedback/request` (with the backend running) and there should be three templates visible, which can be previewed. Two of the templates have questions and one does not. As part of this feature, you should also be able to create new ad-hoc templates with a question, save it, and then see it appear on the page. Previewing the ad-hoc template will allow you to confirm that the question was saved as well.