### PR TITLE
Feature 1298/refactor feedback request to reference feedback template

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequest.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequest.java
@@ -4,6 +4,7 @@ import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.model.DataType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.jetbrains.annotations.Nls;
 
 import javax.annotation.Nullable;
 import javax.persistence.Column;
@@ -45,6 +46,12 @@ public class FeedbackRequest {
     @Schema(description = "id of the person who was requested to give feedback", required = true)
     private UUID recipientId;
 
+    @Column(name = "template_id")
+    @NotBlank
+    @TypeDef(type = DataType.STRING)
+    @Schema(description = "id of the template the feedback request references", required = true)
+    private UUID templateId;
+
     @Column(name="send_date")
     @NotBlank
     @Schema(description = "date request was sent", required = true)
@@ -66,44 +73,28 @@ public class FeedbackRequest {
     @Schema(description = "date the recipient submitted feedback for the request")
     private LocalDate submitDate;
 
-    public FeedbackRequest(@NotNull UUID creatorId,
-                           @NotNull UUID requesteeId,
-                           @NotNull UUID recipientId,
-                           @NotNull LocalDate sendDate,
+    public FeedbackRequest(UUID creatorId,
+                           UUID requesteeId,
+                           UUID recipientId,
+                           UUID templateId,
+                           LocalDate sendDate,
                            @Nullable LocalDate dueDate,
-                           @NotNull String status,
+                           String status,
                            @Nullable LocalDate submitDate) {
         this.id = null;
         this.creatorId = creatorId;
         this.requesteeId = requesteeId;
         this.recipientId = recipientId;
+        this.templateId = templateId;
         this.sendDate = sendDate;
         this.dueDate = dueDate;
         this.status = status;
         this.submitDate = submitDate;
     }
 
-    public FeedbackRequest(@NotNull UUID id,
-                           @NotNull UUID creatorId,
-                           @NotNull UUID requesteeId,
-                           @NotNull UUID recipientId,
-                           @NotNull LocalDate sendDate,
+    public FeedbackRequest(UUID id,
                            @Nullable LocalDate dueDate,
-                           @NotNull String status,
-                           @Nullable LocalDate submitDate) {
-        this.id = id;
-        this.creatorId = creatorId;
-        this.requesteeId = requesteeId;
-        this.recipientId = recipientId;
-        this.sendDate = sendDate;
-        this.dueDate = dueDate;
-        this.status = status;
-        this.submitDate = submitDate;
-    }
-
-    public FeedbackRequest(@NotNull UUID id,
-                           @Nullable LocalDate dueDate,
-                           @NotNull String status,
+                           String status,
                            @Nullable LocalDate submitDate) {
         this.id = id;
         this.dueDate = dueDate;
@@ -143,6 +134,15 @@ public class FeedbackRequest {
 
     public void setRecipientId(UUID recipientId) {
         this.recipientId = recipientId;
+    }
+
+
+    public UUID getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(UUID templateId) {
+        this.templateId = templateId;
     }
 
     public LocalDate getSendDate() {
@@ -189,6 +189,7 @@ public class FeedbackRequest {
                 && Objects.equals(creatorId, that.creatorId)
                 && Objects.equals(requesteeId, that.requesteeId)
                 && Objects.equals(recipientId, that.recipientId)
+                && Objects.equals(templateId, that.templateId)
                 && Objects.equals(sendDate, that.sendDate)
                 && Objects.equals(dueDate, that.dueDate)
                 && Objects.equals(status, that.status)
@@ -197,7 +198,7 @@ public class FeedbackRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, creatorId, recipientId, requesteeId, sendDate, dueDate, status, submitDate);
+        return Objects.hash(id, creatorId, recipientId, requesteeId, sendDate, templateId, dueDate, status, submitDate);
     }
 
     @Override
@@ -207,6 +208,7 @@ public class FeedbackRequest {
                 ", creatorId=" + creatorId +
                 ", recipientId=" + recipientId +
                 ", requesteeId=" + requesteeId +
+                ", templateId='" + templateId +
                 ", sendDate=" + sendDate +
                 ", dueDate=" + dueDate +
                 ", status='" + status +

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequest.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequest.java
@@ -4,7 +4,6 @@ import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.model.DataType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.jetbrains.annotations.Nls;
 
 import javax.annotation.Nullable;
 import javax.persistence.Column;
@@ -12,7 +11,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.UUID;

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
@@ -108,7 +108,6 @@ public class FeedbackRequestController {
      *
      * @param creatorId The {@link UUID} of the creator of the request
      * @param requesteeId The {@link UUID} of the requestee
-     * @param templateId The {@link UUID} of the feedback template
      * @param oldestDate The date that filters out any requests that were made before that date
      * @return list of {@link FeedbackRequestResponseDTO}
      */
@@ -129,6 +128,7 @@ public class FeedbackRequestController {
         dto.setCreatorId(feedbackRequest.getCreatorId());
         dto.setRequesteeId(feedbackRequest.getRequesteeId());
         dto.setRecipientId(feedbackRequest.getRecipientId());
+        dto.setTemplateId(feedbackRequest.getTemplateId());
         dto.setSendDate(feedbackRequest.getSendDate());
         dto.setDueDate(feedbackRequest.getDueDate());
         dto.setStatus(feedbackRequest.getStatus());
@@ -142,6 +142,7 @@ public class FeedbackRequestController {
                 dto.getCreatorId(),
                 dto.getRequesteeId(),
                 dto.getRecipientId(),
+                dto.getTemplateId(),
                 dto.getSendDate(),
                 dto.getDueDate(),
                 dto.getStatus(),

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestCreateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestCreateDTO.java
@@ -3,6 +3,7 @@ package com.objectcomputing.checkins.services.feedback_request;
 import io.micronaut.core.annotation.Introspected;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -10,19 +11,23 @@ import java.util.UUID;
 @Introspected
 public class FeedbackRequestCreateDTO {
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the feedback request creator", required = true)
     private UUID creatorId;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the person who is getting feedback requested on them", required = true)
     private UUID requesteeId;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the person who was requested to give feedback", required = true)
     private UUID recipientId;
 
+    @NotBlank
+    @Schema(description = "id of the template the feedback request references", required = true)
+    private UUID templateId;
 
+    @NotBlank
     @Schema(description = "date request was sent")
     private LocalDate sendDate;
 
@@ -30,7 +35,7 @@ public class FeedbackRequestCreateDTO {
     @Schema(description = "date request is due (may be nullable)")
     private LocalDate dueDate;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "completion status of request", required = true)
     private String status;
 
@@ -61,6 +66,14 @@ public class FeedbackRequestCreateDTO {
 
     public void setRecipientId(UUID recipientId) {
         this.recipientId = recipientId;
+    }
+
+    public UUID getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(UUID templateId) {
+        this.templateId = templateId;
     }
 
     public LocalDate getSendDate() {

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestResponseDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestResponseDTO.java
@@ -4,29 +4,34 @@ import io.micronaut.core.annotation.Introspected;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import java.util.UUID;
 
 @Introspected
 public class FeedbackRequestResponseDTO {
 
-    @NotNull
+    @NotBlank
     @Schema(description = "unique id of the feedback request", required = true)
     private UUID id;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the person who was requested to give feedback", required = true)
     private UUID recipientId;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the feedback request creator", required = true)
     private UUID creatorId;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "id of the person who is getting feedback requested on them", required = true)
     private UUID requesteeId;
 
+    @NotBlank
+    @Schema(description = "id of the template the feedback request references", required = true)
+    private UUID templateId;
+
+    @NotBlank
     @Schema(description = "date request was sent")
     private LocalDate sendDate;
 
@@ -34,7 +39,7 @@ public class FeedbackRequestResponseDTO {
     @Schema(description = "date request is due, if applicable")
     private LocalDate dueDate;
 
-    @NotNull
+    @NotBlank
     @Schema(description = "completion status of request", required = true)
     private String status;
 
@@ -75,6 +80,13 @@ public class FeedbackRequestResponseDTO {
         this.requesteeId = requesteeId;
     }
 
+    public UUID getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(UUID templateId) {
+        this.templateId = templateId;
+    }
 
     public LocalDate getSendDate() {
         return sendDate;

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -106,6 +106,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         feedbackRequest.setCreatorId(originalFeedback.getCreatorId());
         feedbackRequest.setRecipientId(originalFeedback.getRecipientId());
         feedbackRequest.setRequesteeId(originalFeedback.getRequesteeId());
+        feedbackRequest.setTemplateId(originalFeedback.getTemplateId());
         feedbackRequest.setSendDate(originalFeedback.getSendDate());
 
         boolean statusUpdateAttempted = !originalFeedback.getStatus().equals(feedbackRequest.getStatus());

--- a/server/src/main/resources/db/common/V81__alter_feedback_requests_table.sql
+++ b/server/src/main/resources/db/common/V81__alter_feedback_requests_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feedback_requests
+ADD COLUMN template_id varchar REFERENCES feedback_templates(id);

--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -427,11 +427,11 @@ VALUES
 ('2cb80a06-e723-482f-af9b-6b9516cabfcd', '2559a257-ae84-4076-9ed4-3820c427beeb', 'Sample Template', 'This template does not have any questions on it', '2021-04-04', null, null);
 
 INSERT INTO feedback_requests
-(id, creator_id, requestee_id, recipient_id, send_date, due_date, submit_date, status)
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
 VALUES
-('d62b5c09-7ff9-4b0a-bfee-7f467470a7ef', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '1b4f99da-ef70-4a76-9b37-8bb783b749ad', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '2021-07-07', null, null, 'pending');
+('d62b5c09-7ff9-4b0a-bfee-7f467470a7ef', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '1b4f99da-ef70-4a76-9b37-8bb783b749ad', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '2cb80a06-e723-482f-af9b-6b9516cabfcd', '2021-07-07', null, null, 'pending');
 
 INSERT INTO feedback_requests
-(id, creator_id, requestee_id, recipient_id, send_date, due_date, submit_date, status)
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
 VALUES
-('ab7b21d4-f88c-4494-9b0b-8541636025eb', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '2021-07-07', null, null, 'pending');
+('ab7b21d4-f88c-4494-9b0b-8541636025eb', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '67dc3a3b-5bfa-4759-997a-fb6bac98dcf3', '2cb80a06-e723-482f-af9b-6b9516cabfcd', '2021-07-07', null, null, 'pending');

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -33,7 +33,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile templateCreator = createADefaultSupervisor();
         FeedbackTemplate template = createFeedbackTemplate(templateCreator.getId());
         getFeedbackTemplateRepository().save(template);
-        FeedbackRequest feedbackRequest = createFeedbackRequest(sender, requestee, recipient, template.getId());
+        FeedbackRequest feedbackRequest = saveSampleFeedbackRequest(sender, requestee, recipient, template.getId());
         TemplateQuestion question = saveTemplateQuestion(template, 1);
         return createFeedbackAnswer(question.getId(), feedbackRequest.getId());
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -31,9 +31,9 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         createDefaultRole(RoleType.PDL, sender);
         MemberProfile requestee = createADefaultMemberProfileForPdl(sender);
         MemberProfile templateCreator = createADefaultSupervisor();
-        FeedbackRequest feedbackRequest = createFeedbackRequest(sender, requestee, recipient);
         FeedbackTemplate template = createFeedbackTemplate(templateCreator.getId());
         getFeedbackTemplateRepository().save(template);
+        FeedbackRequest feedbackRequest = createFeedbackRequest(sender, requestee, recipient, template.getId());
         TemplateQuestion question = saveTemplateQuestion(template, 1);
         return createFeedbackAnswer(question.getId(), feedbackRequest.getId());
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestControllerTest.java
@@ -109,22 +109,18 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
     }
 
     private void assertResponseEqualsEntity(FeedbackRequest feedbackRequest, FeedbackRequestResponseDTO dto) {
-        assertEquals(feedbackRequest.getId(), dto.getId());
+        // If the feedback request is newly created, then only the response should have an ID
+        if (feedbackRequest.getId() == null) {
+            assertNotNull(dto.getId());
+        } else {
+            assertEquals(feedbackRequest.getId(), dto.getId());
+        }
         assertEquals(feedbackRequest.getCreatorId(), dto.getCreatorId());
         assertEquals(feedbackRequest.getRequesteeId(), dto.getRequesteeId());
+        assertEquals(feedbackRequest.getTemplateId(), dto.getTemplateId());
         assertEquals(feedbackRequest.getSendDate(), dto.getSendDate());
         assertEquals(feedbackRequest.getDueDate(), dto.getDueDate());
-        assertEquals(feedbackRequest.getTemplateId(), dto.getTemplateId());
         assertEquals(feedbackRequest.getRecipientId(), dto.getRecipientId());
-    }
-
-    private void assertResponseEqualsCreate(FeedbackRequestResponseDTO entity, FeedbackRequestCreateDTO dto) {
-        assertEquals(entity.getCreatorId(), dto.getCreatorId());
-        assertEquals(entity.getRequesteeId(), dto.getRequesteeId());
-        assertEquals(entity.getSendDate(), dto.getSendDate());
-        assertEquals(entity.getStatus(), dto.getStatus());
-        assertEquals(entity.getDueDate(), dto.getDueDate());
-        assertEquals(entity.getRecipientId(), dto.getRecipientId());
     }
 
     @Test
@@ -147,7 +143,7 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
         //assert that content of some feedback request equals the test
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertTrue(response.getBody().isPresent());
-        assertResponseEqualsCreate(response.getBody().get(), dto);
+        assertResponseEqualsEntity(feedbackRequest, response.getBody().get());
     }
 
     @Test
@@ -170,7 +166,7 @@ public class FeedbackRequestControllerTest extends TestContainersSuite implement
         //assert that content of some feedback request equals the test
         assertEquals(HttpStatus.CREATED, response.getStatus());
         assertTrue(response.getBody().isPresent());
-        assertResponseEqualsCreate(response.getBody().get(), dto);
+        assertResponseEqualsEntity(feedbackRequest, response.getBody().get());
     }
 
     @Test

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
@@ -1,6 +1,7 @@
 package com.objectcomputing.checkins.services.fixture;
 import com.objectcomputing.checkins.services.feedback_request.FeedbackRequest;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfile;
+
 import java.time.LocalDate;
 
 import java.util.UUID;
@@ -10,11 +11,25 @@ public interface FeedbackRequestFixture extends RepositoryFixture {
     /**
      * Creates a sample feedback request
      * @param creator The {@link MemberProfile} of the creator of the feedback request
+     * @param requestee The {@link MemberProfile} of the requestee of the feedback request
+     * @param recipient The {@link MemberProfile} of the member giving feedback
+     * @param templateId The UUID of the FeedbackTemplate
+     * @return The created {@link FeedbackRequest}
+     */
+    default FeedbackRequest createSampleFeedbackRequest(MemberProfile creator, MemberProfile requestee, MemberProfile recipient, UUID templateId) {
+        LocalDate testDate = LocalDate.of(2010, 10, 8);
+        return new FeedbackRequest(creator.getId(), requestee.getId(), recipient.getId(), templateId, testDate, null, "pending", null);
+    }
+
+    /**
+     * Saves a sample feedback request
+     * @param creator The {@link MemberProfile} of the creator of the feedback request
      * @param recipient The {@link MemberProfile} of the member giving feedback
      * @param requestee The {@link MemberProfile} of the requestee of the feedback request
+     * @param templateId The UUID of the FeedbackTemplate
      * @return The saved {@link FeedbackRequest}
      */
-    default FeedbackRequest createFeedbackRequest(MemberProfile creator, MemberProfile requestee, MemberProfile recipient, UUID templateId) {
+    default FeedbackRequest saveSampleFeedbackRequest(MemberProfile creator, MemberProfile requestee, MemberProfile recipient, UUID templateId) {
         LocalDate testDate = LocalDate.of(2010, 10, 8);
         return getFeedbackRequestRepository().save(new FeedbackRequest(creator.getId(), requestee.getId(), recipient.getId(), templateId, testDate, null, "pending", null));
     }

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackRequestFixture.java
@@ -14,9 +14,9 @@ public interface FeedbackRequestFixture extends RepositoryFixture {
      * @param requestee The {@link MemberProfile} of the requestee of the feedback request
      * @return The saved {@link FeedbackRequest}
      */
-    default FeedbackRequest createFeedbackRequest(MemberProfile creator, MemberProfile requestee, MemberProfile recipient) {
+    default FeedbackRequest createFeedbackRequest(MemberProfile creator, MemberProfile requestee, MemberProfile recipient, UUID templateId) {
         LocalDate testDate = LocalDate.of(2010, 10, 8);
-        return getFeedbackRequestRepository().save(new FeedbackRequest(UUID.randomUUID(), creator.getId(), requestee.getId(), recipient.getId(), testDate, null, "pending", null));
+        return getFeedbackRequestRepository().save(new FeedbackRequest(creator.getId(), requestee.getId(), recipient.getId(), templateId, testDate, null, "pending", null));
     }
 
     default MemberProfile createADefaultRecipient() {


### PR DESCRIPTION
This continues the backend refactor started in issue #1296. A feedback request now references a feedback template. (Previously, a frozen template referenced a feedback request). This refactor will be finished in #1300 

Closes #1298 