### PR TITLE
Feature 1300/alter template backend update

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -103,6 +103,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         feedbackRequest.setRequesteeId(originalFeedback.getRequesteeId());
         feedbackRequest.setTemplateId(originalFeedback.getTemplateId());
         feedbackRequest.setSendDate(originalFeedback.getSendDate());
+        feedbackRequest.setTemplateId(originalFeedback.getTemplateId());
 
         boolean dueDateUpdateAttempted = !Objects.equals(originalFeedback.getDueDate(), feedbackRequest.getDueDate());
         boolean submitDateUpdateAttempted = !Objects.equals(originalFeedback.getSubmitDate(), feedbackRequest.getSubmitDate());

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplate.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplate.java
@@ -2,7 +2,6 @@ package com.objectcomputing.checkins.services.feedback_template;
 
 import io.micronaut.data.annotation.AutoPopulated;
 import io.micronaut.data.annotation.DateCreated;
-import io.micronaut.data.annotation.DateUpdated;
 import io.micronaut.data.annotation.TypeDef;
 import io.micronaut.data.model.DataType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -50,18 +49,11 @@ public class FeedbackTemplate {
     @Schema(description = "date the template was created", required = true)
     private LocalDate dateCreated;
 
-    @Column(name = "updater_id")
-    @Nullable
-    @TypeDef(type = DataType.STRING)
-    @Schema(description = "UUID of person who last updated the feedback template")
-    private UUID updaterId;
-
-    @Column(name = "date_updated")
-    @DateUpdated
-    @Nullable
-    @TypeDef(type = DataType.DATE)
-    @Schema(description = "date the template was last updated")
-    private LocalDate dateUpdated;
+    @Column(name = "active")
+    @NotBlank
+    @TypeDef(type = DataType.BOOLEAN)
+    @Schema(description = "whether or not the template is allowed to be used for a feedback request", required = true)
+    private Boolean active;
 
     /**
      * Constructs a new {@link FeedbackTemplate} to save
@@ -75,22 +67,18 @@ public class FeedbackTemplate {
         this.title = title;
         this.description = description;
         this.creatorId = creatorId;
-        this.updaterId = null;
+        this.active = true;
     }
 
     /**
      * Constructs a {@link FeedbackTemplate} to update
      *
      * @param id The existing {@link UUID} of the template
-     * @param title The updated title of the template
-     * @param description The optional updated description of the template
-     * @param updaterId The {@link UUID} of the user who most recently updated the template
+     * @param active Whether or not the template is allowed to be used for a feedback request
      */
-    public FeedbackTemplate(@NotBlank UUID id, @NotBlank String title, @Nullable String description, @Nullable UUID updaterId) {
+    public FeedbackTemplate(@NotBlank UUID id, @NotBlank Boolean active) {
         this.id = id;
-        this.title = title;
-        this.description = description;
-        this.updaterId = updaterId;
+        this.active = active;
     }
 
     public FeedbackTemplate () {}
@@ -136,22 +124,12 @@ public class FeedbackTemplate {
         this.dateCreated = dateCreated;
     }
 
-    @Nullable
-    public UUID getUpdaterId() {
-        return updaterId;
+    public Boolean getActive() {
+        return active;
     }
 
-    public void setUpdaterId(@Nullable UUID updaterId) {
-        this.updaterId = updaterId;
-    }
-
-    @Nullable
-    public LocalDate getDateUpdated() {
-        return dateUpdated;
-    }
-
-    public void setDateUpdated(@Nullable LocalDate dateUpdated) {
-        this.dateUpdated = dateUpdated;
+    public void setActive(Boolean active) {
+        this.active = active;
     }
 
     @Override
@@ -164,13 +142,12 @@ public class FeedbackTemplate {
                 Objects.equals(description, that.description) &&
                 Objects.equals(creatorId, that.creatorId) &&
                 Objects.equals(dateCreated, that.dateCreated) &&
-                Objects.equals(updaterId, that.updaterId) &&
-                Objects.equals(dateUpdated, that.dateUpdated);
+                Objects.equals(active, that.active);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, title, description, creatorId, dateCreated, updaterId, dateUpdated);
+        return Objects.hash(id, title, description, creatorId, dateCreated, active);
     }
 
     @Override
@@ -181,8 +158,7 @@ public class FeedbackTemplate {
                 ", description='" + description +
                 ", creatorId=" + creatorId +
                 ", dateCreated=" + dateCreated +
-                ", updaterId=" + updaterId +
-                ", dateUpdated=" + dateUpdated +
+                ", active=" + active +
                 '}';
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplate.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplate.java
@@ -24,6 +24,7 @@ public class FeedbackTemplate {
     @Schema(description = "unique id of the feedback template ", required = true)
     private UUID id;
 
+
     @Column(name = "title")
     @NotBlank
     @TypeDef(type = DataType.STRING)
@@ -44,7 +45,6 @@ public class FeedbackTemplate {
 
     @Column(name = "date_created")
     @DateCreated
-    @NotBlank
     @TypeDef(type = DataType.DATE)
     @Schema(description = "date the template was created", required = true)
     private LocalDate dateCreated;
@@ -62,7 +62,7 @@ public class FeedbackTemplate {
      * @param description An optional description of the template
      * @param creatorId The {@link UUID} of the user who created the template
      */
-    public FeedbackTemplate(@NotBlank String title, @Nullable String description, @NotBlank UUID creatorId) {
+    public FeedbackTemplate(String title, @Nullable String description, UUID creatorId) {
         this.id = null;
         this.title = title;
         this.description = description;
@@ -76,7 +76,7 @@ public class FeedbackTemplate {
      * @param id The existing {@link UUID} of the template
      * @param active Whether or not the template is allowed to be used for a feedback request
      */
-    public FeedbackTemplate(@NotBlank UUID id, @NotBlank Boolean active) {
+    public FeedbackTemplate(UUID id, Boolean active) {
         this.id = id;
         this.active = active;
     }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateController.java
@@ -132,7 +132,7 @@ public class FeedbackTemplateController {
      * @return {@link FeedbackTemplate}
      */
     private FeedbackTemplate fromDTO(FeedbackTemplateUpdateDTO dto) {
-        return new FeedbackTemplate(dto.getId(), dto.getTitle(), dto.getDescription(), dto.getUpdaterId());
+        return new FeedbackTemplate(dto.getId(), dto.getActive());
     }
 
     /**
@@ -147,8 +147,7 @@ public class FeedbackTemplateController {
         dto.setDescription(feedbackTemplate.getDescription());
         dto.setCreatorId(feedbackTemplate.getCreatorId());
         dto.setDateCreated(feedbackTemplate.getDateCreated());
-        dto.setUpdaterId(feedbackTemplate.getUpdaterId());
-        dto.setDateUpdated(feedbackTemplate.getDateUpdated());
+        dto.setActive(feedbackTemplate.getActive());
         return dto;
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateCreateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateCreateDTO.java
@@ -1,16 +1,10 @@
 package com.objectcomputing.checkins.services.feedback_template;
 
-import com.objectcomputing.checkins.services.feedback_template.template_question.TemplateQuestionCreateDTO;
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.data.annotation.TypeDef;
-import io.micronaut.data.model.DataType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 
 @Introspected

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateCreateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateCreateDTO.java
@@ -2,6 +2,8 @@ package com.objectcomputing.checkins.services.feedback_template;
 
 import com.objectcomputing.checkins.services.feedback_template.template_question.TemplateQuestionCreateDTO;
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.data.annotation.TypeDef;
+import io.micronaut.data.model.DataType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.annotation.Nullable;
@@ -26,6 +28,10 @@ public class FeedbackTemplateCreateDTO {
     @Schema(description = "UUID of person who created the feedback template", required = true)
     private UUID creatorId;
 
+    @NotBlank
+    @Schema(description = "whether or not the template is allowed to be used for a feedback request", required = true)
+    private Boolean active;
+
     public String getTitle() {
         return title;
     }
@@ -49,5 +55,13 @@ public class FeedbackTemplateCreateDTO {
 
     public void setCreatorId(UUID creatorId) {
         this.creatorId = creatorId;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateRepository.java
@@ -1,5 +1,6 @@
 package com.objectcomputing.checkins.services.feedback_template;
 
+import io.micronaut.data.annotation.Query;
 import io.micronaut.data.jdbc.annotation.JdbcRepository;
 import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
@@ -14,9 +15,12 @@ import java.util.UUID;
 @JdbcRepository(dialect = Dialect.POSTGRES)
 public interface FeedbackTemplateRepository extends CrudRepository<FeedbackTemplate, UUID> {
 
-    List<FeedbackTemplate> findByTitleLike(String title);
+    List<FeedbackTemplate> findByTitleLikeAndActive(String title, Boolean active);
 
-    List<FeedbackTemplate> findByCreatorId(UUID id);
+    List<FeedbackTemplate> findByCreatorIdAndActive(UUID id, Boolean active);
+
+    @Query(value = "UPDATE feedback_templates SET active = false WHERE id = :id")
+    Optional<FeedbackTemplate> softDeleteById(@NotNull String id);
 
     @Override
     <S extends FeedbackTemplate> S save(@Valid @NotNull @NonNull S entity);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateRepository.java
@@ -6,6 +6,7 @@ import io.micronaut.data.model.query.builder.sql.Dialect;
 import io.micronaut.data.repository.CrudRepository;
 import io.reactivex.annotations.NonNull;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -14,10 +15,6 @@ import java.util.UUID;
 
 @JdbcRepository(dialect = Dialect.POSTGRES)
 public interface FeedbackTemplateRepository extends CrudRepository<FeedbackTemplate, UUID> {
-
-    List<FeedbackTemplate> findByTitleLikeAndActive(String title, Boolean active);
-
-    List<FeedbackTemplate> findByCreatorIdAndActive(UUID id, Boolean active);
 
     @Query(value = "UPDATE feedback_templates SET active = false WHERE id = :id")
     Optional<FeedbackTemplate> softDeleteById(@NotNull String id);
@@ -29,5 +26,15 @@ public interface FeedbackTemplateRepository extends CrudRepository<FeedbackTempl
     <S extends FeedbackTemplate> S update(@Valid @NotNull @NonNull S entity);
 
     Optional<FeedbackTemplate> findById(@NonNull UUID id);
+
+    @Query(value = "SELECT * " +
+            "FROM feedback_templates " +
+            "WHERE (active = true)" +
+            "AND (:creatorId IS NULL OR creator_id = :creatorId) " +
+            "AND (:title IS NULL OR title LIKE CONCAT('%',:title,'%'))"
+            , nativeQuery = true)
+    List<FeedbackTemplate> searchByValues(@Nullable String creatorId, @Nullable String title);
+
+
 
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateResponseDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateResponseDTO.java
@@ -23,7 +23,7 @@ public class FeedbackTemplateResponseDTO {
     @Schema(description = "description of the feedback template")
     private String description;
 
-    @Nullable
+    @NotBlank
     @Schema(description = "ID of person who created the feedback template", required = true)
     private UUID creatorId;
 
@@ -60,12 +60,11 @@ public class FeedbackTemplateResponseDTO {
         this.description = description;
     }
 
-    @Nullable
     public UUID getCreatorId() {
         return creatorId;
     }
 
-    public void setCreatorId(@Nullable UUID creatorId) {
+    public void setCreatorId(UUID creatorId) {
         this.creatorId = creatorId;
     }
 

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateResponseDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateResponseDTO.java
@@ -8,7 +8,6 @@ import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import java.util.UUID;
 
-
 @Introspected
 public class FeedbackTemplateResponseDTO {
 
@@ -33,12 +32,8 @@ public class FeedbackTemplateResponseDTO {
     private LocalDate dateCreated;
 
     @NotBlank
-    @Schema(description = "UUID of person who last updated the feedback template")
-    private UUID updaterId;
-
-    @Nullable
-    @Schema(description = "date the template was last updated")
-    private LocalDate dateUpdated;
+    @Schema(description = "whether or not the template is allowed to be used for a feedback request", required = true)
+    private Boolean active;
 
     public UUID getId() {
         return id;
@@ -82,20 +77,11 @@ public class FeedbackTemplateResponseDTO {
         this.dateCreated = dateCreated;
     }
 
-    public UUID getUpdaterId() {
-        return updaterId;
+    public Boolean getActive() {
+        return active;
     }
 
-    public void setUpdaterId(UUID updaterId) {
-        this.updaterId = updaterId;
-    }
-
-    @Nullable
-    public LocalDate getDateUpdated() {
-        return dateUpdated;
-    }
-
-    public void setDateUpdated(@Nullable LocalDate dateUpdated) {
-        this.dateUpdated = dateUpdated;
+    public void setActive(Boolean active) {
+        this.active = active;
     }
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateServicesImpl.java
@@ -3,7 +3,6 @@ package com.objectcomputing.checkins.services.feedback_template;
 import com.objectcomputing.checkins.exceptions.BadArgException;
 import com.objectcomputing.checkins.exceptions.NotFoundException;
 import com.objectcomputing.checkins.exceptions.PermissionException;
-import com.objectcomputing.checkins.services.feedback_template.template_question.*;
 import com.objectcomputing.checkins.services.memberprofile.MemberProfileServices;
 import com.objectcomputing.checkins.services.memberprofile.currentuser.CurrentUserServices;
 import com.objectcomputing.checkins.util.Util;
@@ -19,35 +18,21 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
     private final FeedbackTemplateRepository feedbackTemplateRepository;
     private final CurrentUserServices currentUserServices;
     private final MemberProfileServices memberProfileServices;
-    private final TemplateQuestionServices templateQuestionServices;
 
     public FeedbackTemplateServicesImpl(FeedbackTemplateRepository feedbackTemplateRepository,
                                         MemberProfileServices memberProfileServices,
-                                        CurrentUserServices currentUserServices,
-                                        TemplateQuestionServices templateQuestionServices) {
+                                        CurrentUserServices currentUserServices) {
         this.feedbackTemplateRepository = feedbackTemplateRepository;
         this.currentUserServices = currentUserServices;
         this.memberProfileServices = memberProfileServices;
-        this.templateQuestionServices = templateQuestionServices;
     }
 
     @Override
     public FeedbackTemplate save(FeedbackTemplate feedbackTemplate) {
-
-        if (feedbackTemplate == null) {
-            throw new BadArgException("Feedback template object is null and cannot be saved");
-        } else if (feedbackTemplate.getId() != null) {
-            throw new BadArgException("Attempted to save template with non-auto-populated ID");
-        }
-
         try {
             memberProfileServices.getById(feedbackTemplate.getCreatorId());
         } catch (NotFoundException e) {
             throw new BadArgException("Creator ID is invalid");
-        }
-
-        if (!createIsPermitted()) {
-            throw new PermissionException("You are not authorized to do this operation");
         }
 
         return feedbackTemplateRepository.save(feedbackTemplate);
@@ -56,9 +41,7 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
     @Override
     public FeedbackTemplate update(FeedbackTemplate feedbackTemplate) {
 
-        if (feedbackTemplate == null) {
-            throw new BadArgException("Feedback template object is null and cannot be updated");
-        } else if (feedbackTemplate.getId() == null) {
+       if (feedbackTemplate.getId() == null) {
             throw new BadArgException("Attempted to update template with null ID");
         }
 
@@ -99,43 +82,15 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
             throw new NotFoundException("No feedback template with ID " + id);
         }
 
-        if (!getIsPermitted()) {
-            throw new PermissionException("You are not authorized to do this operation");
-        }
 
         return feedbackTemplate.get();
     }
 
     @Override
     public List<FeedbackTemplate> findByFields(@Nullable UUID creatorId, @Nullable String title) {
-        if (!getIsPermitted()) {
-            throw new PermissionException("You are not authorized to do this operation");
-        }
-
-        List<FeedbackTemplate> templateList = new ArrayList<>();
-
-        if (title != null) {
-            templateList.addAll(findByTitleLike(title));
-            if (creatorId != null) {
-                templateList.retainAll(feedbackTemplateRepository.findByCreatorIdAndActive(creatorId, true));
-            }
-        } else if (creatorId != null) {
-            templateList.addAll(feedbackTemplateRepository.findByCreatorIdAndActive(creatorId, true));
-        } else {
-            feedbackTemplateRepository.findAll().forEach(templateList::add);
-        }
-        return templateList;
+        return feedbackTemplateRepository.searchByValues(Util.nullSafeUUIDToString(creatorId), title);
     }
 
-    protected List<FeedbackTemplate> findByTitleLike(String title) {
-        String wildcard = "%" + title + "%";
-        return feedbackTemplateRepository.findByTitleLikeAndActive(wildcard, true);
-    }
-
-    public boolean createIsPermitted() {
-        UUID currentUserId = currentUserServices.getCurrentUser().getId();
-        return currentUserId != null;
-    }
 
     public boolean updateIsPermitted(UUID creatorId) {
         UUID currentUserId = currentUserServices.getCurrentUser().getId();
@@ -143,9 +98,6 @@ public class FeedbackTemplateServicesImpl implements FeedbackTemplateServices {
         return isAdmin || currentUserId.equals(creatorId);
     }
 
-    public boolean getIsPermitted() {
-        return createIsPermitted();
-    }
 
     public boolean deleteIsPermitted(UUID creatorId) {
         return updateIsPermitted(creatorId);

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateUpdateDTO.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_template/FeedbackTemplateUpdateDTO.java
@@ -2,7 +2,6 @@ package com.objectcomputing.checkins.services.feedback_template;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 import java.util.UUID;
 import io.micronaut.core.annotation.Introspected;
@@ -15,16 +14,8 @@ public class FeedbackTemplateUpdateDTO {
     private UUID id;
 
     @NotBlank
-    @Schema(description = "the updated title of the feedback template", required = true)
-    private String title;
-
-    @Nullable
-    @Schema(description = "the updated description of the feedback template")
-    private String description;
-
-    @NotBlank
-    @Schema(description = "UUID of person who last updated the feedback template")
-    private UUID updaterId;
+    @Schema(description = "whether or not the template is allowed to be used for a feedback request", required = true)
+    private Boolean active;
 
     public UUID getId() {
         return id;
@@ -34,28 +25,11 @@ public class FeedbackTemplateUpdateDTO {
         this.id = id;
     }
 
-    public String getTitle() {
-        return title;
+    public Boolean getActive() {
+        return active;
     }
 
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    @Nullable
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(@Nullable String description) {
-        this.description = description;
-    }
-
-    public UUID getUpdaterId() {
-        return updaterId;
-    }
-
-    public void setUpdaterId(UUID updaterId) {
-        this.updaterId = updaterId;
+    public void setActive(Boolean active) {
+        this.active = active;
     }
 }

--- a/server/src/main/resources/db/common/V82__alter_feedback_template_table.sql
+++ b/server/src/main/resources/db/common/V82__alter_feedback_template_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE feedback_templates
+ADD COLUMN active boolean;

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -27,7 +27,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
     @Client("/services/feedback/answers")
     HttpClient client;
 
-    public FeedbackAnswer saveSampleAnswer(MemberProfile sender, MemberProfile recipient) {
+    public FeedbackAnswer createSampleAnswer(MemberProfile sender, MemberProfile recipient) {
         createDefaultRole(RoleType.PDL, sender);
         MemberProfile requestee = createADefaultMemberProfileForPdl(sender);
         MemberProfile templateCreator = createADefaultSupervisor();
@@ -35,7 +35,11 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         getFeedbackTemplateRepository().save(template);
         FeedbackRequest feedbackRequest = saveSampleFeedbackRequest(sender, requestee, recipient, template.getId());
         TemplateQuestion question = saveTemplateQuestion(template, 1);
-        return createFeedbackAnswer(question.getId(), feedbackRequest.getId());
+        return createSampleFeedbackAnswer(question.getId(), feedbackRequest.getId());
+    }
+
+    public FeedbackAnswer saveSampleAnswer(MemberProfile sender, MemberProfile recipient) {
+        return getFeedbackAnswerRepository().save(createSampleAnswer(sender, recipient));
     }
 
     FeedbackAnswerCreateDTO createDTO(FeedbackAnswer feedbackAnswer) {
@@ -73,7 +77,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
 
         MemberProfile sender = createASecondDefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
-        FeedbackAnswerCreateDTO dto = createDTO(saveSampleAnswer(sender, recipient));
+        FeedbackAnswerCreateDTO dto = createDTO(createSampleAnswer(sender, recipient));
 
         final HttpRequest<?> request = HttpRequest.POST("", dto)
                 .basicAuth(admin.getWorkEmail(), RoleType.Constants.ADMIN_ROLE);
@@ -87,9 +91,9 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
     void testPostAnswerByRecipient() {
         MemberProfile sender = createADefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
-
-        FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
+        FeedbackAnswer feedbackAnswer = createSampleAnswer(sender, recipient);
         FeedbackAnswerCreateDTO dto = createDTO(feedbackAnswer);
+
         final HttpRequest<?> request = HttpRequest.POST("", dto)
                 .basicAuth(recipient.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpResponse<FeedbackAnswerResponseDTO> response = client.toBlocking().exchange(request, FeedbackAnswerResponseDTO.class);
@@ -103,7 +107,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
     void testPostBySenderUnauthorized() {
         MemberProfile sender = createADefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
-        FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
+        FeedbackAnswer feedbackAnswer = createSampleAnswer(sender, recipient);
         FeedbackAnswerCreateDTO dto = createDTO(feedbackAnswer);
         final HttpRequest<?> request = HttpRequest.POST("", dto)
                 .basicAuth(sender.getWorkEmail(), RoleType.Constants.PDL_ROLE);
@@ -112,7 +116,6 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
 
         assertUnauthorized(exception);
     }
-
 
     @Test
     void testUpdateByRecipient() {

--- a/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/feedback_answer/FeedbackAnswerControllerTest.java
@@ -33,13 +33,14 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile templateCreator = createADefaultSupervisor();
         FeedbackTemplate template = createFeedbackTemplate(templateCreator.getId());
         getFeedbackTemplateRepository().save(template);
-        FeedbackRequest feedbackRequest = saveSampleFeedbackRequest(sender, requestee, recipient, template.getId());
         TemplateQuestion question = saveTemplateQuestion(template, 1);
+        FeedbackRequest feedbackRequest = saveSampleFeedbackRequest(sender, requestee, recipient, template.getId());
         return createSampleFeedbackAnswer(question.getId(), feedbackRequest.getId());
     }
 
     public FeedbackAnswer saveSampleAnswer(MemberProfile sender, MemberProfile recipient) {
-        return getFeedbackAnswerRepository().save(createSampleAnswer(sender, recipient));
+        FeedbackAnswer answer = createSampleAnswer(sender, recipient);
+        return getFeedbackAnswerRepository().save(answer);
     }
 
     FeedbackAnswerCreateDTO createDTO(FeedbackAnswer feedbackAnswer) {
@@ -109,6 +110,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile recipient = createADefaultRecipient();
         FeedbackAnswer feedbackAnswer = createSampleAnswer(sender, recipient);
         FeedbackAnswerCreateDTO dto = createDTO(feedbackAnswer);
+
         final HttpRequest<?> request = HttpRequest.POST("", dto)
                 .basicAuth(sender.getWorkEmail(), RoleType.Constants.PDL_ROLE);
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,
@@ -125,6 +127,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         feedbackAnswer.setAnswer(":p");
         feedbackAnswer.setSentiment(1.0);
         FeedbackAnswerUpdateDTO dto = updateDTO(feedbackAnswer);
+
         final HttpRequest<?> request = HttpRequest.PUT("", dto)
                 .basicAuth(recipient.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpResponse<FeedbackAnswerResponseDTO> response = client.toBlocking()
@@ -143,6 +146,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile recipient = createADefaultRecipient();
         FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
         FeedbackAnswerUpdateDTO dto = updateDTO(feedbackAnswer);
+
         final HttpRequest<?> request = HttpRequest.PUT("", dto)
                 .basicAuth(admin.getWorkEmail(), RoleType.Constants.ADMIN_ROLE);
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,
@@ -156,6 +160,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile sender = createADefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
         FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
+
         final HttpRequest<?> request = HttpRequest.GET(String.format("/%s", feedbackAnswer.getId()))
                 .basicAuth(sender.getWorkEmail(), RoleType.Constants.PDL_ROLE);
         final HttpResponse<FeedbackAnswerResponseDTO> response = client.toBlocking().exchange(request, FeedbackAnswerResponseDTO.class);
@@ -170,6 +175,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile sender = createADefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
         FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
+
         final HttpRequest<?> request = HttpRequest.GET(String.format("/%s", feedbackAnswer.getId()))
                 .basicAuth(recipient.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpResponse<FeedbackAnswerResponseDTO> response = client.toBlocking().exchange(request, FeedbackAnswerResponseDTO.class);
@@ -185,6 +191,7 @@ public class FeedbackAnswerControllerTest extends TestContainersSuite implements
         MemberProfile sender = createASecondDefaultMemberProfile();
         MemberProfile recipient = createADefaultRecipient();
         FeedbackAnswer feedbackAnswer = saveSampleAnswer(sender, recipient);
+
         final HttpRequest<?> request = HttpRequest.GET(String.format("/%s", feedbackAnswer.getId()))
                 .basicAuth(random.getWorkEmail(), RoleType.Constants.MEMBER_ROLE);
         final HttpClientResponseException exception = assertThrows(HttpClientResponseException.class,

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackAnswerFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/FeedbackAnswerFixture.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 
 public interface FeedbackAnswerFixture extends RepositoryFixture {
 
-    default FeedbackAnswer createFeedbackAnswer(UUID questionId, UUID requestId) {
-        return getFeedbackAnswerRepository().save(new FeedbackAnswer("I am doing just fine", questionId, requestId, 0.5));
+    default FeedbackAnswer createSampleFeedbackAnswer(UUID questionId, UUID requestId) {
+        return new FeedbackAnswer("I am doing just fine", questionId, requestId, 0.5);
     }
 
 }

--- a/web-ui/src/components/feedback_request_card/FeedbackRequestCard.test.js
+++ b/web-ui/src/components/feedback_request_card/FeedbackRequestCard.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import {AppContextProvider } from "../../context/AppContext";
+import FeedbackRequestCard from "./FeedbackRequestCard";
+
+it("renders correctly", () => {
+  snapshot(
+    <BrowserRouter>
+      <AppContextProvider>
+        <FeedbackRequestCard requesteeName="test" requesteeTitle="test" templateName="test"/>
+      </AppContextProvider>
+    </BrowserRouter>
+
+  );
+});

--- a/web-ui/src/components/feedback_request_card/__snapshots__/FeedbackRequestCard.test.js.snap
+++ b/web-ui/src/components/feedback_request_card/__snapshots__/FeedbackRequestCard.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="feedback-request-card"
+>
+  <div
+    className="MuiPaper-root MuiCard-root makeStyles-root-1 MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      className="has-padding-top"
+    >
+      <div
+        className="MuiCardContent-root"
+      >
+        <div
+          className="MuiGrid-root MuiGrid-container"
+        >
+          <div
+            className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          >
+            <div
+              className="MuiGrid-root no-wrap MuiGrid-container MuiGrid-align-items-xs-center"
+            >
+              <div
+                className="MuiGrid-root MuiGrid-item"
+              >
+                <div
+                  className="MuiAvatar-root MuiAvatar-circle avatar"
+                >
+                  <img
+                    className="MuiAvatar-img"
+                    src="../../../public/default_profile.jpg"
+                  />
+                </div>
+              </div>
+              <div
+                className="MuiGrid-root small-margin MuiGrid-item MuiGrid-grid-xs-true"
+              >
+                <p
+                  className="MuiTypography-root person-name MuiTypography-body1"
+                >
+                  test
+                </p>
+                <p
+                  className="MuiTypography-root position-text MuiTypography-body1"
+                >
+                  test
+                </p>
+              </div>
+              <div
+                className="MuiGrid-root align-end MuiGrid-item MuiGrid-grid-xs-4"
+              >
+                <p
+                  className="MuiTypography-root dark-gray-text MuiTypography-body1"
+                >
+                  test
+                </p>
+                <a
+                  className="response-link red-text"
+                  href="/"
+                  onClick={[Function]}
+                >
+                  View all responses
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiCardActions-root"
+    >
+      <button
+        aria-expanded={false}
+        aria-label="show more"
+        className="MuiButtonBase-root MuiIconButton-root makeStyles-expandClose-2"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.test.js
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import {AppContextProvider } from "../../../context/AppContext";
+import FeedbackRequestSubcard from "./FeedbackRequestSubcard";
+
+it("renders correctly", () => {
+  snapshot(
+    <BrowserRouter>
+      <AppContextProvider>
+        <FeedbackRequestSubcard recipientName="test" recipientTitle="test"/>
+      </AppContextProvider>
+    </BrowserRouter>
+
+  );
+});

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+Array [
+  <hr
+    className="MuiDivider-root person-divider"
+  />,
+  <div
+    className="MuiGrid-root person-row MuiGrid-container MuiGrid-spacing-xs-6"
+  >
+    <div
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+    >
+      <div
+        className="MuiGrid-root no-wrap MuiGrid-container MuiGrid-align-items-xs-center"
+      >
+        <div
+          className="MuiGrid-root MuiGrid-item"
+        >
+          <div
+            className="MuiAvatar-root MuiAvatar-circle avatar"
+          >
+            <img
+              className="MuiAvatar-img"
+              src="../../../public/default_profile.jpg"
+            />
+          </div>
+        </div>
+        <div
+          className="MuiGrid-root small-margin MuiGrid-item MuiGrid-grid-xs-true"
+        >
+          <p
+            className="MuiTypography-root person-name MuiTypography-body1"
+          >
+            test
+          </p>
+          <p
+            className="MuiTypography-root position-text MuiTypography-body1"
+          >
+            test
+          </p>
+        </div>
+        <div
+          className="MuiGrid-root align-end MuiGrid-item MuiGrid-grid-xs-4"
+        >
+          <p
+            className="MuiTypography-root MuiTypography-body1"
+          >
+            Submitted 5/22
+          </p>
+          <a
+            className="response-link"
+            href="/"
+            onClick={[Function]}
+          >
+            View response
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/web-ui/src/pages/ViewFeedbackPage.test.js
+++ b/web-ui/src/pages/ViewFeedbackPage.test.js
@@ -1,0 +1,14 @@
+import React from "react";
+import ViewFeedbackPage from "./ViewFeedbackPage";
+import {AppContextProvider} from "../context/AppContext";
+import {BrowserRouter} from "react-router-dom";
+
+   it("renders correctly", () => {
+     snapshot(
+         <AppContextProvider>
+           <BrowserRouter>
+             <ViewFeedbackPage/>
+           </BrowserRouter>
+         </AppContextProvider>
+     );
+   });

--- a/web-ui/src/pages/__snapshots__/ViewFeedbackPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/ViewFeedbackPage.test.js.snap
@@ -1,0 +1,216 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="view-feedback-page"
+>
+  <div
+    className="view-feedback-header-container"
+  >
+    <h4
+      className="MuiTypography-root makeStyles-pageTitle-1 MuiTypography-h4"
+    >
+      Feedback Requests
+    </h4>
+    <div
+      className="input-row"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root makeStyles-searchField-3"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
+          onClick={[Function]}
+        >
+          <div
+            className="MuiInputAdornment-root MuiInputAdornment-positionStart"
+            style={
+              Object {
+                "color": "gray",
+              }
+            }
+          >
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+              />
+            </svg>
+          </div>
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedStart"
+            disabled={false}
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Search..."
+            required={false}
+            type="text"
+          />
+        </div>
+        <p
+          className="MuiFormHelperText-root"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "&#8203;",
+              }
+            }
+          />
+        </p>
+      </div>
+      <div
+        className="MuiFormControl-root makeStyles-textField-2"
+      >
+        <div
+          className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+        >
+          <label
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense MuiInputLabel-outlined MuiFormLabel-filled"
+            data-shrink={true}
+            htmlFor="select-time"
+            id="select-time-label"
+          >
+            Show requests sent within
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+            onClick={[Function]}
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby="select-time-label select-time"
+              className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+              id="select-time"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              Past 3 months
+            </div>
+            <input
+              aria-hidden={true}
+              autoFocus={false}
+              className="MuiSelect-nativeInput"
+              onAnimationStart={[Function]}
+              onChange={[Function]}
+              required={false}
+              tabIndex={-1}
+              value="3mo"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden={true}
+              className="PrivateNotchedOutline-root-6 MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                className="PrivateNotchedOutline-legendLabelled-8 PrivateNotchedOutline-legendNotched-9"
+              >
+                <span>
+                  Show requests sent within
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        className="MuiFormControl-root makeStyles-textField-2"
+      >
+        <div
+          className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+        >
+          <label
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense MuiInputLabel-outlined MuiFormLabel-filled"
+            data-shrink={true}
+            htmlFor="select-sort-method"
+            id="select-sort-method-label"
+          >
+            Sort by
+          </label>
+          <div
+            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-marginDense MuiOutlinedInput-marginDense"
+            onClick={[Function]}
+          >
+            <div
+              aria-haspopup="listbox"
+              aria-labelledby="select-sort-method-label select-sort-method"
+              className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMarginDense MuiOutlinedInput-inputMarginDense"
+              id="select-sort-method"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              Date request was sent
+            </div>
+            <input
+              aria-hidden={true}
+              autoFocus={false}
+              className="MuiSelect-nativeInput"
+              onAnimationStart={[Function]}
+              onChange={[Function]}
+              required={false}
+              tabIndex={-1}
+              value="sent_date"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSelect-icon MuiSelect-iconOutlined"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden={true}
+              className="PrivateNotchedOutline-root-6 MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                className="PrivateNotchedOutline-legendLabelled-8 PrivateNotchedOutline-legendNotched-9"
+              >
+                <span>
+                  Sort by
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="feedback-requests-list-container"
+  >
+    <h5
+      className="MuiTypography-root makeStyles-notFoundMessage-5 MuiTypography-h5"
+    >
+      No feedback requests found
+    </h5>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Closes #1300 

This feature is another installment of the major refactors started in issues #1296 and #1298. The goal of this issue is to remove the ability to update certain fields of templates, including the template title and description. 

The only field that can be updated is `active`, which is a method for soft-deleting templates. When a template is soft-deleted, it will still show up as part of past feedback requests, but it will be inaccessible for creating new feedback requests (unless it is reactivated)