### PR TITLE
Bugfix 1104/team members not showing in directory when scheduled termination

### DIFF
--- a/web-ui/src/components/member-directory/MemberSummaryCard.jsx
+++ b/web-ui/src/components/member-directory/MemberSummaryCard.jsx
@@ -19,7 +19,6 @@ import {
   Typography,
 } from "@material-ui/core";
 
-import isPast from 'date-fns/isPast'
 
 const useStyles = makeStyles(() => ({
   header: {
@@ -43,30 +42,6 @@ const MemberSummaryCard = ({ member }) => {
   const pdlProfile = selectProfileMap(state)[pdlId];
 
   const classes = useStyles();
-
-  // if the current user is an admin, show the alert icon if the user has a termination date
-  // if the current user is not an admin, only show the alert icon if they have a termination date and it is past the present day
-  const decideAvatar = () => {
-    if (isAdmin){
-      return terminationDate?
-        (
-          <Avatar className={"large"}>
-            <PriorityHighIcon />
-          </Avatar>
-        )
-        :
-        (<Avatar className={"large"} src={getAvatarURL(workEmail)} />)
-    }
-    else {
-      return terminationDate && isPast(new Date(terminationDate)) ? 
-      (
-        <Avatar className={"large"}>
-          <PriorityHighIcon />
-        </Avatar>
-      ) : 
-      (<Avatar className={"large"} src={getAvatarURL(workEmail)} />)
-    }
-  }
   
   return (
     <Box display="flex" flexWrap="wrap">
@@ -88,7 +63,16 @@ const MemberSummaryCard = ({ member }) => {
               </Typography>
             }
             disableTypography
-            avatar={decideAvatar()}
+            avatar={isAdmin && terminationDate? 
+              (
+                <Avatar className={"large"}>
+                  <PriorityHighIcon />
+                </Avatar>
+              ) : 
+              (
+                <Avatar className={"large"} src={getAvatarURL(workEmail)} />
+              )
+            }
           />
         </Link>
         <CardContent>

--- a/web-ui/src/components/member-directory/MemberSummaryCard.jsx
+++ b/web-ui/src/components/member-directory/MemberSummaryCard.jsx
@@ -19,7 +19,7 @@ import {
   Typography,
 } from "@material-ui/core";
 
-import { isPast } from "date-fns/esm";
+import isPast from 'date-fns/isPast'
 
 const useStyles = makeStyles(() => ({
   header: {

--- a/web-ui/src/components/member-directory/MemberSummaryCard.jsx
+++ b/web-ui/src/components/member-directory/MemberSummaryCard.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 
 import { AppContext } from "../../context/AppContext";
-import { selectProfileMap } from "../../context/selectors";
+import { selectIsAdmin, selectProfileMap } from "../../context/selectors";
 import { getAvatarURL } from "../../api/api.js";
 
 import { Card, CardHeader } from "@material-ui/core";
@@ -19,6 +19,8 @@ import {
   Typography,
 } from "@material-ui/core";
 
+import { isPast } from "date-fns/esm";
+
 const useStyles = makeStyles(() => ({
   header: {
     cursor: "pointer",
@@ -27,6 +29,7 @@ const useStyles = makeStyles(() => ({
 
 const MemberSummaryCard = ({ member }) => {
   const { state } = useContext(AppContext);
+  const isAdmin = selectIsAdmin(state);
   const {
     location,
     name,
@@ -41,6 +44,30 @@ const MemberSummaryCard = ({ member }) => {
 
   const classes = useStyles();
 
+  // if the current user is an admin, show the alert icon if the user has a termination date
+  // if the current user is not an admin, only show the alert icon if they have a termination date and it is past the present day
+  const decideAvatar = () => {
+    if (isAdmin){
+      return terminationDate?
+        (
+          <Avatar className={"large"}>
+            <PriorityHighIcon />
+          </Avatar>
+        )
+        :
+        (<Avatar className={"large"} src={getAvatarURL(workEmail)} />)
+    }
+    else {
+      return terminationDate && isPast(new Date(terminationDate)) ? 
+      (
+        <Avatar className={"large"}>
+          <PriorityHighIcon />
+        </Avatar>
+      ) : 
+      (<Avatar className={"large"} src={getAvatarURL(workEmail)} />)
+    }
+  }
+  
   return (
     <Box display="flex" flexWrap="wrap">
       <Card className={"member-card"}>
@@ -61,15 +88,7 @@ const MemberSummaryCard = ({ member }) => {
               </Typography>
             }
             disableTypography
-            avatar={
-              !terminationDate ? (
-                <Avatar className={"large"} src={getAvatarURL(workEmail)} />
-              ) : (
-                <Avatar className={"large"}>
-                  <PriorityHighIcon />
-                </Avatar>
-              )
-            }
+            avatar={decideAvatar()}
           />
         </Link>
         <CardContent>


### PR DESCRIPTION
This had been partially fixed already.  Terminated members with a date set in the future _do_ show up in the directory as intended.  However, their user profile was replaced with an alert icon making it obvious to regular users which members had an impending termination.  This fixes that so only admins will see the alert icon. 