### PR TITLE
Bugfix 1365/members cant add themselves to guild

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
@@ -41,27 +41,22 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
     }
 
     public GuildMember save(@Valid @NotNull GuildMember guildMember) {
-        MemberProfile currentUser = currentUserServices.getCurrentUser();
-        boolean isAdmin = currentUserServices.isAdmin();
-
         final UUID guildId = guildMember.getGuildId();
         final UUID memberId = guildMember.getMemberId();
         Optional<Guild> guild = guildRepo.findById(guildId);
+
         if (guild.isEmpty()) {
             throw new BadArgException(String.format("Guild %s doesn't exist", guildId));
-        }
-
-        Set<GuildMember> guildLeads = this.findByFields(guildId, null, true);
-
-        if (guildMember.getId() != null) {
+        } else if (guildMember.getId() != null) {
             throw new BadArgException(String.format("Found unexpected id %s for Guild member", guildMember.getId()));
         } else if (memberRepo.findById(memberId).isEmpty()) {
             throw new BadArgException(String.format("Member %s doesn't exist", memberId));
         } else if (guildMemberRepo.findByGuildIdAndMemberId(guildMember.getGuildId(), guildMember.getMemberId()).isPresent()) {
             throw new BadArgException(String.format("Member %s already exists in guild %s", memberId, guildId));
-        } else if (!isAdmin && guildLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
+        } else if (!currentUserServices.isAdmin() && guildMember.isLead()) {
             throw new BadArgException("You are not authorized to perform this operation");
         }
+
         GuildMember guildMemberSaved = guildMemberRepo.save(guildMember);
         guildMemberHistoryRepository.save(buildGuildMemberHistory(guildId,memberId,"Added", LocalDateTime.now()));
         return guildMemberSaved;
@@ -119,22 +114,19 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
 
     public void delete(@NotNull UUID id) {
         MemberProfile currentUser = currentUserServices.getCurrentUser();
-        boolean isAdmin = currentUserServices.isAdmin();
-
         GuildMember guildMember = guildMemberRepo.findById(id).orElse(null);
-        if (guildMember != null) {
-            Set<GuildMember> guildLeads = this.findByFields(guildMember.getGuildId(), null, true);
 
-            if (!isAdmin && guildLeads.stream().noneMatch(o -> o.getMemberId().equals(currentUser.getId()))) {
-                throw new PermissionException("You are not authorized to perform this operation");
-            } else {
-                guildMemberRepo.deleteById(id);
-            }
-        } else {
-            throw new NotFoundException(String.format("Unable to locate guildMember with id %s", id));
+        if (guildMember == null) throw new BadArgException(String.format("Unable to locate guildMember with id %s", id));
+
+        Set<GuildMember> guildLeads = this.findByFields(guildMember.getGuildId(), null, true);
+        boolean isLead = guildLeads.stream().anyMatch(o -> o.getMemberId().equals(currentUser.getId()));
+        // if the current user is not an admin, is not the same as the member in the request, and is not a lead in the guild
+        if (!currentUserServices.isAdmin() && !guildMember.getMemberId().equals(currentUser.getId()) && !isLead) {
+            throw new PermissionException("You are not authorized to perform this operation");
         }
-        guildMemberHistoryRepository.save(buildGuildMemberHistory(guildMember.getGuildId(),guildMember.getMemberId(),"Deleted", LocalDateTime.now()));
 
+        guildMemberRepo.deleteById(id);
+        guildMemberHistoryRepository.save(buildGuildMemberHistory(guildMember.getGuildId(),guildMember.getMemberId(),"Deleted", LocalDateTime.now()));
     }
 
     private static GuildMemberHistory buildGuildMemberHistory(UUID guildId, UUID memberId, String change, LocalDateTime date) {

--- a/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/guild/member/GuildMemberServicesImpl.java
@@ -129,9 +129,14 @@ public class GuildMemberServicesImpl implements GuildMemberServices {
         if (guildMember == null) throw new NotFoundException(String.format("Unable to locate guildMember with id %s", id));
 
         Set<GuildMember> guildLeads = this.findByFields(guildMember.getGuildId(), null, true);
-        boolean isLead = guildLeads.stream().anyMatch(o -> o.getMemberId().equals(currentUser.getId()));
+        boolean currentUserIsLead = guildLeads.stream().anyMatch(o -> o.getMemberId().equals(currentUser.getId()));
+
+        // don't allow guild lead to be removed if they are the only lead
+        if (guildMember.isLead() && guildLeads.size() == 1){
+            throw new BadArgException("At least one guild lead must be present in the guild at all times");
+        }
         // if the current user is not an admin, is not the same as the member in the request, and is not a lead in the guild -> don't delete
-        if (!currentUserServices.isAdmin() && !guildMember.getMemberId().equals(currentUser.getId()) && !isLead) {
+        if (!currentUserServices.isAdmin() && !guildMember.getMemberId().equals(currentUser.getId()) && !currentUserIsLead) {
             throw new PermissionException("You are not authorized to perform this operation");
         }
 

--- a/server/src/test/java/com/objectcomputing/checkins/services/fixture/MemberProfileFixture.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/fixture/MemberProfileFixture.java
@@ -23,7 +23,6 @@ public interface MemberProfileFixture extends RepositoryFixture {
                 memberProfile.getId(), null,null,null,null));
     }
 
-    // this user is not connected to other users in the system
     default MemberProfile createAnUnrelatedUser() {
         return getMemberProfileRepository().save(new MemberProfile("Nobody", null, " Really",
                 null, "Comedic Relief", null, "New York, New York",

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
@@ -488,7 +488,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
     }
 
     @Test
-    void testMemberRemovesThemselfFromGuild() {
+    void testMemberCanRemoveThemselfFromGuild() {
         Guild guild = createDefaultGuild();
         MemberProfile memberProfile = createADefaultMemberProfile();
 
@@ -503,7 +503,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
     }
 
     @Test
-    void testDeleteGuildMemberWithUnrelatedUser() {
+    void testDeleteGuildMemberWithUnrelatedUserThrowsException() {
         Guild guild = createDefaultGuild();
         MemberProfile memberProfile = createADefaultMemberProfile();
         GuildMember guildMember = createDefaultGuildMember(guild, memberProfile);

--- a/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
+++ b/server/src/test/java/com/objectcomputing/checkins/services/guild/member/GuildMemberControllerTest.java
@@ -84,6 +84,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
         // Create a member and add him to guild
         MemberProfile memberProfileOfUser = createAnUnrelatedUser();
         GuildMemberCreateDTO guildMemberCreateDTO = new GuildMemberCreateDTO(guild.getId(), memberProfileOfUser.getId(), false);
+
         final HttpRequest<GuildMemberCreateDTO> request = HttpRequest.POST("", guildMemberCreateDTO).basicAuth(memberProfileOfGuildmate.getWorkEmail(), MEMBER_ROLE);
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
@@ -94,7 +95,7 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
 
         assertEquals(request.getPath(), href);
         assertEquals("You are not authorized to perform this operation", error);
-        assertEquals(HttpStatus.BAD_REQUEST, responseException.getStatus());
+        assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
     }
 
     @Test
@@ -487,20 +488,37 @@ class GuildMemberControllerTest extends TestContainersSuite implements GuildFixt
     }
 
     @Test
-    void testDeleteGuildMemberWithoutAdminPrivilege() {
+    void testMemberRemovesThemselfFromGuild() {
         Guild guild = createDefaultGuild();
         MemberProfile memberProfile = createADefaultMemberProfile();
 
         GuildMember guildMember = createDefaultGuildMember(guild, memberProfile);
 
         final HttpRequest<Object> request = HttpRequest.
-                DELETE(String.format("/%s", guildMember.getId())).basicAuth(MEMBER_ROLE, MEMBER_ROLE);
+                DELETE(String.format("/%s", guildMember.getId())).basicAuth(memberProfile.getWorkEmail(), MEMBER_ROLE);
+
+        final HttpResponse<GuildMember> response = client.toBlocking().exchange(request, GuildMember.class);
+
+        assertEquals(HttpStatus.OK, response.getStatus());
+    }
+
+    @Test
+    void testDeleteGuildMemberWithUnrelatedUser() {
+        Guild guild = createDefaultGuild();
+        MemberProfile memberProfile = createADefaultMemberProfile();
+        GuildMember guildMember = createDefaultGuildMember(guild, memberProfile);
+
+        MemberProfile unrelatedUser = createAnUnrelatedUser();
+
+        final HttpRequest<Object> request = HttpRequest.
+                DELETE(String.format("/%s", guildMember.getId())).basicAuth(unrelatedUser.getWorkEmail(), MEMBER_ROLE);
 
         HttpClientResponseException responseException = assertThrows(HttpClientResponseException.class,
                 () -> client.toBlocking().exchange(request, Map.class));
 
         assertNotNull(responseException.getResponse());
         assertEquals(HttpStatus.FORBIDDEN, responseException.getStatus());
+
     }
 
     @Test


### PR DESCRIPTION
Allows users to add themselves to guilds.  Prevents guild leads from removing themselves if they are the only guild lead. 