### PR TITLE
Link to responses page based on request ID

### DIFF
--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.jsx
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.jsx
@@ -87,7 +87,9 @@ const FeedbackRequestSubcard = (props) => {
                   </IconButton>
                 </Tooltip>
               }
-              {props.request.submitDate ? <Link to="" className="response-link"> View response </Link> : null}
+              {props.request.submitDate && props.request.id
+                ? <Link to={`/feedback/view/responses/?request=${props.request.id}`} className="response-link">View response</Link>
+                : null}
             </Grid>
           </Grid>
         </Grid>

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
@@ -51,10 +51,10 @@ Array [
           </p>
           <a
             className="response-link"
-            href="/"
+            href="/feedback/view/responses/?request=c15961e4-6e9b-42cd-8140-ece9efe2445c"
             onClick={[Function]}
           >
-             View response 
+            View response
           </a>
         </div>
       </div>


### PR DESCRIPTION
To test this, log in as Geetika and go to:
```
http://localhost:3000/feedback/view/
```

Click "View response" on Mark's card and you should be redirected to the following page:
```
localhost:3000/feedback/view/responses/?request=c15961e4-6e9b-42cd-8140-ece9efe2445c
```

The contents of the page should be some sample questions and answers. Actual answer showing is dependent on pull request #1363 