### PR TITLE
Feature 1374/fix url validations on feedback request flow

### DIFF
--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -279,7 +279,6 @@ const FeedbackRequestPage = () => {
   }, [activeStep, hasFor, hasFrom, hasSend, query, templateIsValid]);
 
   useEffect(() => {
-    queryLoaded.current = false;
     const params = queryString.parse(location?.search);
     console.log(params);
     console.log(query);
@@ -292,7 +291,6 @@ const FeedbackRequestPage = () => {
 
   useEffect(() => {
     console.log(query);
-    queryLoaded.current = true;
     if (query.for) {
       setRequestee(selectProfile(state, query.for));
     }

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -321,7 +321,6 @@ const FeedbackRequestPage = () => {
   }, [canProceed]);
 
   return (
-    queryLoaded.current &&
     <div className="feedback-request-page">
       <div className="header-container">
         <Typography className={classes.requestHeader} variant="h4">Feedback Request for <b>{requestee?.name}</b></Typography>


### PR DESCRIPTION
To test this, go to:
```
localhost:3000/feedback/request
```
You should get an error toast regarding the URL.

If you go to:
```
localhost:3000/feedback/request/?for=1b4f99da-ef70-4a76-9b37-8bb783b749ad
```
then that URL should work. Stepping through the request process should not produce any errors. If you change anything in the URL to be invalid (e.g. cut off part of an ID) then you should get an error toast (it will either redirect you or remove that specific query, depending on which ID you altered)

Additionally, for any of the URLs that are generated when stepping through (meaning you didn't manually alter the URL), you should be able to reload the page and return to the same screen with no redirect, errors, or toasts.