### PR TITLE
Bugfix 1405/incorrect pdl display

### DIFF
--- a/web-ui/src/components/profile/Profile.jsx
+++ b/web-ui/src/components/profile/Profile.jsx
@@ -73,8 +73,8 @@ const Profile = ({ memberId, pdlId, checkinPdlId }) => {
   // Get Checkin PDL's name
   useEffect(() => {
     async function getCheckinPDLName() {
-      if (pdlId) {
-        let res = await getMember(pdlId, csrf);
+      if (checkinPdlId) {
+        let res = await getMember(checkinPdlId, csrf);
         let checkinPdlProfile =
           res.payload.data && !res.error ? res.payload.data : undefined;
         setCheckinPdl(checkinPdlProfile ? checkinPdlProfile.name : "");

--- a/web-ui/src/components/profile/Profile.jsx
+++ b/web-ui/src/components/profile/Profile.jsx
@@ -38,18 +38,21 @@ const useStyles = makeStyles((theme) => ({
   },
   smallAvatar: {
     marginRight: "16px",
-  }
+  },
 }));
 
-const Profile = ({memberId, pdlId}) => {
+const Profile = ({ memberId, pdlId, checkinPdlId }) => {
   const classes = useStyles();
   const { state } = useContext(AppContext);
   const { csrf } = state;
   const userProfile = selectProfileMap(state)[memberId];
 
-  const { workEmail, name, title, location, supervisorid } = userProfile ? userProfile : {};
+  const { workEmail, name, title, location, supervisorid } = userProfile
+    ? userProfile
+    : {};
 
   const [pdl, setPDL] = useState();
+  const [checkinPdl, setCheckinPdl] = useState();
   const [supervisor, setSupervisor] = useState();
 
   // Get PDL's name
@@ -66,6 +69,21 @@ const Profile = ({memberId, pdlId}) => {
       getPDLName();
     }
   }, [csrf, pdlId]);
+
+  // Get Checkin PDL's name
+  useEffect(() => {
+    async function getCheckinPDLName() {
+      if (pdlId) {
+        let res = await getMember(pdlId, csrf);
+        let checkinPdlProfile =
+          res.payload.data && !res.error ? res.payload.data : undefined;
+        setCheckinPdl(checkinPdlProfile ? checkinPdlProfile.name : "");
+      }
+    }
+    if (csrf) {
+      getCheckinPDLName();
+    }
+  }, [csrf, checkinPdlId]);
 
   // Get Supervisor's name
   useEffect(() => {
@@ -95,17 +113,26 @@ const Profile = ({memberId, pdlId}) => {
         <div>
           <div className={classes.header}>
             <Hidden smUp>
-              <Avatar className={classes.smallAvatar} src={getAvatarURL(workEmail)} />
+              <Avatar
+                className={classes.smallAvatar}
+                src={getAvatarURL(workEmail)}
+              />
             </Hidden>
             <div className={classes.title}>
               <Typography variant="h5" component="h2">
                 {name}
               </Typography>
-              <Typography color="textSecondary" component="h3">{title}</Typography>
+              <Typography color="textSecondary" component="h3">
+                {title}
+              </Typography>
             </div>
           </div>
           <Typography variant="body2" color="textSecondary" component="p">
-            <a href={`mailto:${workEmail}`} target="_blank" rel="noopener noreferrer">
+            <a
+              href={`mailto:${workEmail}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {workEmail}
             </a>
             <br />
@@ -113,7 +140,9 @@ const Profile = ({memberId, pdlId}) => {
             <br />
             Supervisor: {supervisor}
             <br />
-            PDL: {pdl}
+            Current PDL: {pdl}
+            <br />
+            {checkinPdl && `PDL @ time of Checkin: ${checkinPdl}`}
           </Typography>
         </div>
       </div>

--- a/web-ui/src/components/profile/__snapshots__/Profile.test.jsx.snap
+++ b/web-ui/src/components/profile/__snapshots__/Profile.test.jsx.snap
@@ -35,7 +35,8 @@ exports[`renders correctly 1`] = `
         <br />
         Supervisor: 
         <br />
-        PDL: 
+        Current PDL: 
+        <br />
       </p>
     </div>
   </div>

--- a/web-ui/src/pages/CheckinsPage.jsx
+++ b/web-ui/src/pages/CheckinsPage.jsx
@@ -115,7 +115,7 @@ const CheckinsPage = () => {
         <Grid item xs={12} sm={9}>
           <Profile
             memberId={selectedProfile?.id || currentUserId}
-            pdlId={currentCheckin ? currentCheckin.pdlId : null}
+            pdlId={selectedProfile ? selectedProfile.pdlId : null}
           />
           <div className={classes.navigate}>
             <CheckinsHistory

--- a/web-ui/src/pages/CheckinsPage.jsx
+++ b/web-ui/src/pages/CheckinsPage.jsx
@@ -116,6 +116,7 @@ const CheckinsPage = () => {
           <Profile
             memberId={selectedProfile?.id || currentUserId}
             pdlId={selectedProfile ? selectedProfile.pdlId : null}
+            checkinPdlId={currentCheckin ? currentCheckin.pdlId : null}
           />
           <div className={classes.navigate}>
             <CheckinsHistory

--- a/web-ui/src/pages/__snapshots__/CheckinsPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/CheckinsPage.test.js.snap
@@ -48,7 +48,8 @@ exports[`renders correctly 1`] = `
               <br />
               Supervisor: 
               <br />
-              PDL: 
+              Current PDL: 
+              <br />
             </p>
           </div>
         </div>


### PR DESCRIPTION
If a member has their PDL changed, I assume it's correct leave their current check-ins pdlIds as the PDL who created them,  @mkimberlin is that correct? Also, currently the code is written so that when a check-in is completed and submitted, the pdlId of the check-in is updated to the id of the PDL who completed and submitted it. Is that the behavior we want? 