### PR TITLE
Feature 1282/filter feedback requests by date range on view page

### DIFF
--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -476,9 +476,14 @@ VALUES
 INSERT INTO feedback_requests
 (id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
 VALUES
-('09fbdaf2-f554-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9','97b0a312-e5dd-46f4-a600-d8be2ad925bb', '2020-07-07', null, '2020-07-07', 'submitted' );
+('09fbdaf2-f554-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9','97b0a312-e5dd-46f4-a600-d8be2ad925bb', '2020-07-07', null, '2020-07-07', 'submitted');
 
 INSERT INTO feedback_requests
 (id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
 VALUES
-('82d9db7c-f554-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9','97b0a312-e5dd-46f4-a600-d8be2ad925bb', '2020-07-05', null, '2020-07-10', 'submitted' );
+('82d9db7c-f554-11eb-9a03-0242ac130003', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', 'b2d35288-7f1e-4549-aa2b-68396b162490', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9','97b0a312-e5dd-46f4-a600-d8be2ad925bb', '2020-07-05', null, '2020-07-10', 'submitted');
+
+INSERT INTO feedback_requests
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
+VALUES
+('e2af1c96-a593-48c2-b9e0-a00193a070c7', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '8fa673c0-ca19-4271-b759-41cb9db2e83a', '43ee8e79-b33d-44cd-b23c-e183894ebfef','18ef2032-c264-411e-a8e1-ddda9a714bae', '2021-08-01', '2021-08-05', '2021-08-02', 'submitted');

--- a/web-ui/src/components/feedback_request_card/FeedbackRequestCard.jsx
+++ b/web-ui/src/components/feedback_request_card/FeedbackRequestCard.jsx
@@ -129,6 +129,9 @@ const FeedbackRequestCard = ({ requesteeId, templateName, responses, sortType, d
         oldestDate.setMonth(oldestDate.getMonth() - 3);
     }
 
+    if (Array.isArray(requestDate)) {
+      requestDate = new Date(requestDate);
+    }
     return requestDate >= oldestDate;
   }, [dateRange]);
 

--- a/web-ui/src/components/feedback_request_card/FeedbackRequestCard.jsx
+++ b/web-ui/src/components/feedback_request_card/FeedbackRequestCard.jsx
@@ -15,6 +15,7 @@ import "./FeedbackRequestCard.css";
 import {selectProfile} from "../../context/selectors";
 import {AppContext} from "../../context/AppContext";
 import { getAvatarURL } from "../../api/api.js";
+import Divider from "@material-ui/core/Divider";
 
 const useStyles = makeStyles({
   root: {
@@ -131,6 +132,32 @@ const FeedbackRequestCard = ({ requesteeId, templateName, responses, sortType, d
     return requestDate >= oldestDate;
   }, [dateRange]);
 
+  const noRequestsMessage = useCallback(() => {
+    let message;
+    switch (dateRange) {
+      case DateRange.THREE_MONTHS:
+        message = "No requests in the past 3 months";
+        break;
+      case DateRange.SIX_MONTHS:
+        message = "No requests in the past 6 months";
+        break;
+      case DateRange.ONE_YEAR:
+        message = "No requests in the past year";
+        break;
+      default:
+        message = "No requests";
+    }
+
+    return (
+      <React.Fragment>
+        <Divider/>
+        <div style={{padding: "12px 12px", textAlign: "center", backgroundColor: "#ececec"}}>
+          <Typography variant="body1">{message}</Typography>
+        </div>
+      </React.Fragment>
+    );
+  }, [dateRange]);
+
   // Sort the responses by either the send date or the submit date
   useEffect(() => {
     let responsesCopy = [...responses];
@@ -155,8 +182,8 @@ const FeedbackRequestCard = ({ requesteeId, templateName, responses, sortType, d
         break;
     }
     responsesCopy.sort(sortMethod);
-    setSortedResponses(responsesCopy); // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortType, dateRange, responses]);
+    setSortedResponses(responsesCopy);
+  }, [state, sortType, dateRange, responses, withinDateRange]);
 
   return (
     <div className="feedback-request-card">
@@ -197,10 +224,13 @@ const FeedbackRequestCard = ({ requesteeId, templateName, responses, sortType, d
           </IconButton>
         </CardActions>
         <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <CardContent>
-            {sortedResponses?.map((response) => (
-              <FeedbackRequestSubcard key={response.id} request={response}/>
-            ))}
+          <CardContent style={{padding: 0}}>
+            {sortedResponses && sortedResponses.length
+              ? sortedResponses.map((response) => (
+                <FeedbackRequestSubcard key={response.id} request={response}/>
+              ))
+              : noRequestsMessage()
+            }
           </CardContent>
         </Collapse>
       </Card>

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.jsx
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/FeedbackRequestSubcard.jsx
@@ -95,7 +95,7 @@ const FeedbackRequestSubcard = ({ request }) => {
   return (
     <React.Fragment>
       <Divider className="person-divider"/>
-      <Grid container spacing={6} className="person-row">
+      <Grid container spacing={6} style={{paddingLeft: "16px", paddingRight: "16px"}} className="person-row">
         <Grid item xs={12}>
           <Grid
             container

--- a/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
+++ b/web-ui/src/components/feedback_request_card/feedback_request_subcard/__snapshots__/FeedbackRequestSubcard.test.js.snap
@@ -7,6 +7,12 @@ Array [
   />,
   <div
     className="MuiGrid-root person-row MuiGrid-container MuiGrid-spacing-xs-6"
+    style={
+      Object {
+        "paddingLeft": "16px",
+        "paddingRight": "16px",
+      }
+    }
   >
     <div
       className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"

--- a/web-ui/src/pages/ViewFeedbackPage.jsx
+++ b/web-ui/src/pages/ViewFeedbackPage.jsx
@@ -50,7 +50,7 @@ const SortOption = {
   RECIPIENT_NAME_REVERSE_ALPHABETICAL: "recipient_name_reverse_alphabetical"
 };
 
-export const DateRange = {
+const DateRange = {
   THREE_MONTHS: "3mo",
   SIX_MONTHS: "6mo",
   ONE_YEAR: "1yr",
@@ -129,6 +129,10 @@ const ViewFeedbackPage = () => {
     });
   }, [currentUserId, csrf, state]);
 
+  useEffect(() => {
+    console.log(dateRange);
+  }, [dateRange]);
+
   const getFilteredFeedbackRequests = useCallback(() => {
     if (feedbackRequests === undefined) {
       return null;
@@ -165,9 +169,10 @@ const ViewFeedbackPage = () => {
         templateName={request?.templateInfo?.title}
         responses={request?.responses}
         sortType={sortValue}
+        dateRange={dateRange}
       />
       ));
-  }, [searchText, sortValue, feedbackRequests, classes.notFoundMessage]);
+  }, [searchText, sortValue, dateRange, feedbackRequests, classes.notFoundMessage]);
 
   return (
     <div className="view-feedback-page">
@@ -189,7 +194,10 @@ const ViewFeedbackPage = () => {
               ),
             }}
           />
-          <FormControl className={classes.textField} value={dateRange}>
+          <FormControl
+            className={classes.textField}
+            value={dateRange}
+          >
             <TextField
               id="select-time"
               select
@@ -197,7 +205,7 @@ const ViewFeedbackPage = () => {
               size="small"
               label="Show requests sent within"
               onChange={(e) => setDateRange(e.target.value)}
-              defaultValue={dateRange}
+              defaultValue={DateRange.THREE_MONTHS}
               variant="outlined"
             >
               <MenuItem value={DateRange.THREE_MONTHS}>Past 3 months</MenuItem>
@@ -210,15 +218,15 @@ const ViewFeedbackPage = () => {
           <FormControl
             className={classes.textField}
             value={sortValue}
-            >
+          >
             <TextField
               id="select-sort-method"
               select
               fullWidth
-              onChange={(e) => setSortValue(e.target.value)}
-              defaultValue={SortOption.SENT_DATE}
               size="small"
               label="Sort by"
+              onChange={(e) => setSortValue(e.target.value)}
+              defaultValue={SortOption.SENT_DATE}
               variant="outlined"
             >
               <MenuItem value={SortOption.SUBMISSION_DATE}>Date feedback was submitted</MenuItem>

--- a/web-ui/src/pages/ViewFeedbackPage.jsx
+++ b/web-ui/src/pages/ViewFeedbackPage.jsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
   }
 });
 
-const DateRange = {
+export const DateRange = {
   THREE_MONTHS: "3mo",
   SIX_MONTHS: "6mo",
   ONE_YEAR: "1yr",

--- a/web-ui/src/pages/ViewFeedbackPage.jsx
+++ b/web-ui/src/pages/ViewFeedbackPage.jsx
@@ -129,10 +129,6 @@ const ViewFeedbackPage = () => {
     });
   }, [currentUserId, csrf, state]);
 
-  useEffect(() => {
-    console.log(dateRange);
-  }, [dateRange]);
-
   const getFilteredFeedbackRequests = useCallback(() => {
     if (feedbackRequests === undefined) {
       return null;

--- a/web-ui/src/pages/ViewFeedbackPage.jsx
+++ b/web-ui/src/pages/ViewFeedbackPage.jsx
@@ -44,6 +44,13 @@ const useStyles = makeStyles({
   }
 });
 
+const DateRange = {
+  THREE_MONTHS: "3mo",
+  SIX_MONTHS: "6mo",
+  ONE_YEAR: "1yr",
+  ALL_TIME: "all"
+};
+
 const ViewFeedbackPage = () => {
 
   const classes = useStyles();
@@ -54,6 +61,7 @@ const ViewFeedbackPage = () => {
   const csrf = selectCsrfToken(state);
   const currentUserId =  selectCurrentUserId(state);
   const gotRequests = useRef(false);
+  const [dateRange, setDateRange] = useState(DateRange.THREE_MONTHS);
 
   useEffect(() => {
     const getFeedbackRequests = async(creatorId) => {
@@ -173,20 +181,21 @@ const ViewFeedbackPage = () => {
               ),
             }}
           />
-          <FormControl className={classes.textField}>
+          <FormControl className={classes.textField} value={dateRange}>
             <TextField
               id="select-time"
               select
               fullWidth
               size="small"
               label="Show requests sent within"
-              value={"3mo"}
+              onChange={(e) => setDateRange(e.target.value)}
+              defaultValue={dateRange}
               variant="outlined"
             >
-              <MenuItem value={"3mo"}>Past 3 months</MenuItem>
-              <MenuItem value={"6mo"}>Past 6 months</MenuItem>
-              <MenuItem value={"1yr"}>Past year</MenuItem>
-              <MenuItem value={"all"}>All time</MenuItem>
+              <MenuItem value={DateRange.THREE_MONTHS}>Past 3 months</MenuItem>
+              <MenuItem value={DateRange.SIX_MONTHS}>Past 6 months</MenuItem>
+              <MenuItem value={DateRange.ONE_YEAR}>Past year</MenuItem>
+              <MenuItem value={DateRange.ALL_TIME}>All time</MenuItem>
             </TextField>
           </FormControl>
 

--- a/web-ui/src/pages/__snapshots__/ViewFeedbackPage.test.js.snap
+++ b/web-ui/src/pages/__snapshots__/ViewFeedbackPage.test.js.snap
@@ -69,13 +69,14 @@ exports[`renders correctly 1`] = `
       </div>
       <div
         className="MuiFormControl-root makeStyles-textField-2"
+        value="3mo"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
         >
           <label
-            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-marginDense MuiInputLabel-outlined MuiFormLabel-filled"
-            data-shrink={true}
+            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-marginDense MuiInputLabel-outlined"
+            data-shrink={false}
             htmlFor="select-time"
             id="select-time-label"
           >
@@ -124,7 +125,7 @@ exports[`renders correctly 1`] = `
               className="PrivateNotchedOutline-root-6 MuiOutlinedInput-notchedOutline"
             >
               <legend
-                className="PrivateNotchedOutline-legendLabelled-8 PrivateNotchedOutline-legendNotched-9"
+                className="PrivateNotchedOutline-legendLabelled-8"
               >
                 <span>
                   Show requests sent within


### PR DESCRIPTION
To test this, log in as Geetika and go to:
```
localhost:3000/feedback/view
```

You should now be able to filter responses by the date they were sent (includes all requests within the selected time range). The current options for this are 3 months, 6 months, 1 year, and all time. This filter should work with the existing sort selector and the search field.