### PR TITLE
Feature 1377/additional front end validation

### DIFF
--- a/web-ui/src/components/feedback_recipient_selector/FeedbackRecipientSelector.jsx
+++ b/web-ui/src/components/feedback_recipient_selector/FeedbackRecipientSelector.jsx
@@ -65,13 +65,14 @@ const FeedbackRecipientSelector = ({changeQuery, fromQuery}) => {
           });
         });
         let newProfiles = selectedMembers.concat(filteredNormalizedMembers)
+        newProfiles.splice(newProfiles.indexOf(userProfile.id), 1)
         setProfiles(newProfiles);
       } else {
         setProfiles(normalizedMembers)
       }
       searchTextUpdated.current = true
     }
-  }, [searchText, profiles, fromQuery, state])
+  }, [searchText, profiles, fromQuery, state, userProfile])
 
   useEffect(() => {
     function bindFromURL() {

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -112,7 +112,7 @@ const FeedbackRequestPage = () => {
     if (from) {
       from = Array.isArray(from) ? from : [from];
       for (let recipientId of from) {
-        if (!memberIds.includes(recipientId)) {
+        if (!memberIds.includes(recipientId) || from.includes(currentUserId)) {
           dispatch({
             type: UPDATE_TOAST,
             payload: {
@@ -123,22 +123,10 @@ const FeedbackRequestPage = () => {
           handleQueryChange("from", undefined);
           return false;
         }
-          if(recipientId === currentUserId) {
-            dispatch({
-              type: UPDATE_TOAST,
-              payload: {
-                severity: "error",
-                toast: "Cannot send feedback request to the requestee",
-              },
-            });
-            //handleQueryChange("from", undefined);
-            from.splice(from.indexOf(currentUserId), 1);
-            return false;
-          }
-        }
+      }
       return true;
     }
-      return false;
+    return false;
   }, [memberIds, query, dispatch, handleQueryChange, currentUserId]);
 
   const isValidDate = useCallback((dateString) => {

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -152,9 +152,9 @@ const FeedbackRequestPage = () => {
   const hasFrom = useCallback(() => {
     let from = query.from;
     if (from) {
-      from = Array.isArray(from) ? from : [from];
-      for (let recipientId of from) {
-        if (!memberIds.includes(recipientId)) {
+      from = Array.isArray(from);
+      if(from.length === 1) {
+        if (!memberIds.includes(from.recipientId)) {
           dispatch({
             type: UPDATE_TOAST,
             payload: {
@@ -165,11 +165,47 @@ const FeedbackRequestPage = () => {
           handleQueryChange("from", undefined);
           return false;
         }
+        if(from.recipientId === currentUserId) {
+          dispatch({
+            type: UPDATE_TOAST,
+            payload: {
+              severity: "error",
+              toast: "Cannot send feedback request to the requestee",
+            },
+          });
+          from.splice(from.indexOf(from.recipientId), 1)
+        }
+        return false;
+      }
+      if(from.length > 1) {
+        for (let recipientId of from) {
+          if (!memberIds.includes(recipientId)) {
+            dispatch({
+              type: UPDATE_TOAST,
+              payload: {
+                severity: "error",
+                toast: "Member ID in URL is invalid",
+              },
+            });
+            handleQueryChange("from", undefined);
+            return false;
+          }
+          if(recipientId === currentUserId) {
+            dispatch({
+              type: UPDATE_TOAST,
+              payload: {
+                severity: "error",
+                toast: "Cannot send feedback request to the requestee",
+              },
+            });
+            from.splice(from.indexOf(recipientId), 1)
+          }
+        }
       }
       return true;
     }
     return false;
-  }, [memberIds, query, dispatch, handleQueryChange]);
+  }, [memberIds, query, dispatch, handleQueryChange, currentUserId, fromQuery]);
 
   const isValidDate = useCallback((dateString) => {
     let today = new Date();

--- a/web-ui/src/pages/FeedbackRequestPage.jsx
+++ b/web-ui/src/pages/FeedbackRequestPage.jsx
@@ -110,9 +110,9 @@ const FeedbackRequestPage = () => {
     if (!memberIds.length) return true;
     let from = query.from;
     if (from) {
-      from = Array.isArray(from);
-      if(from.length === 1) {
-        if (!memberIds.includes(from.recipientId)) {
+      from = Array.isArray(from) ? from : [from];
+      for (let recipientId of from) {
+        if (!memberIds.includes(recipientId)) {
           dispatch({
             type: UPDATE_TOAST,
             payload: {
@@ -123,31 +123,6 @@ const FeedbackRequestPage = () => {
           handleQueryChange("from", undefined);
           return false;
         }
-        if(from.recipientId === currentUserId) {
-          dispatch({
-            type: UPDATE_TOAST,
-            payload: {
-              severity: "error",
-              toast: "Cannot send feedback request to the requestee",
-            },
-          });
-          from.splice(from.indexOf(from.recipientId), 1)
-        }
-        return false;
-      }
-      if(from.length > 1) {
-        for (let recipientId of from) {
-          if (!memberIds.includes(recipientId)) {
-            dispatch({
-              type: UPDATE_TOAST,
-              payload: {
-                severity: "error",
-                toast: "Member ID in URL is invalid",
-              },
-            });
-            handleQueryChange("from", undefined);
-            return false;
-          }
           if(recipientId === currentUserId) {
             dispatch({
               type: UPDATE_TOAST,
@@ -156,14 +131,15 @@ const FeedbackRequestPage = () => {
                 toast: "Cannot send feedback request to the requestee",
               },
             });
-            from.splice(from.indexOf(recipientId), 1)
+            //handleQueryChange("from", undefined);
+            from.splice(from.indexOf(currentUserId), 1);
+            return false;
           }
         }
-      }
       return true;
     }
-    return false;
-  }, [memberIds, query, dispatch, handleQueryChange, currentUserId, fromQuery]);
+      return false;
+  }, [memberIds, query, dispatch, handleQueryChange, currentUserId]);
 
   const isValidDate = useCallback((dateString) => {
     let today = new Date();


### PR DESCRIPTION
When selecting feedback recipients, The current user will no longer show up when searching

To test:

run front and back end
Login as someone who can send feedback requests(We have been using Geetika)
Start a feedback request
when you get to step 2, search for whoever you are logged in as and they should not show up

Closes #1377 