### PR TITLE
Feature 1334/filter by recipient names on feedback responses page

### DIFF
--- a/web-ui/src/components/sentiment_icon/SentimentIcon.jsx
+++ b/web-ui/src/components/sentiment_icon/SentimentIcon.jsx
@@ -59,6 +59,7 @@ const SentimentIcon = (props) => {
     const [sentimentIcon, buttonStyle] = getSentimentStyles(sentimentScore, selectedSentiment === sentimentScore);
     return (
       <IconButton
+        key={sentimentScore}
         onClick={() => setSelectedSentiment(sentimentScore)}
         style={buttonStyle}
       >

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -13,7 +13,7 @@
 }
 
 .view-feedback-responses-page .no-responses-found {
-    background-color: #dcdcdc;
+    background-color: #e5e5e5;
     text-align: center;
     border-radius: 4px;
     padding: 10px;

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -4,6 +4,12 @@
     margin-right: 3em;
 }
 
+.view-feedback-responses-page .responses-filter-container {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 3em;
+}
+
 .question-responses-container {
     display: flex;
     flex-direction: column;

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -34,4 +34,11 @@
         margin-left: 1em;
         margin-right: 1em;
     }
+
+    .view-feedback-responses-page .responses-filter-container {
+        flex-direction: column;
+        align-items: center;
+        height: 200px;
+        margin-bottom: 2em;
+    }
 }

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -12,6 +12,13 @@
     height: 100px;
 }
 
+.view-feedback-responses-page .no-responses-found {
+    background-color: #dcdcdc;
+    text-align: center;
+    border-radius: 4px;
+    padding: 10px;
+}
+
 .question-responses-container {
     display: flex;
     flex-direction: column;

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.css
@@ -7,7 +7,9 @@
 .view-feedback-responses-page .responses-filter-container {
     display: flex;
     flex-direction: row;
+    align-items: flex-end;
     margin-bottom: 3em;
+    height: 100px;
 }
 
 .question-responses-container {

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 import {Avatar, Checkbox, Chip, TextField, Typography} from '@material-ui/core';
 import "./ViewFeedbackResponses.css";
 import {makeStyles} from '@material-ui/core/styles';
@@ -43,6 +43,7 @@ const ViewFeedbackResponses = () => {
   const [responderOptions, setResponderOptions] = useState([]);
   const [selectedResponders, setSelectedResponders] = useState([]);
   const [filteredQuestionsAndAnswers, setFilteredQuestionsAndAnswers] = useState([]);
+  const retrievedQuestionsAndAnswers = useRef(false);
 
   useEffect(() => {
     setQuery(queryString.parse(location?.search));
@@ -85,6 +86,7 @@ const ViewFeedbackResponses = () => {
     setResponderOptions(allResponders);
   }, [state, questionsAndAnswers]);
 
+  // Populate all responders as selected by default
   useEffect(() => {
     setSelectedResponders(responderOptions);
   }, [responderOptions]);
@@ -104,7 +106,13 @@ const ViewFeedbackResponses = () => {
 
     setFilteredQuestionsAndAnswers(responsesToDisplay);
 
-  }, [questionsAndAnswers, searchText, selectedResponders]);
+  }, [searchText, selectedResponders]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!retrievedQuestionsAndAnswers.current && filteredQuestionsAndAnswers.length > 0) {
+      retrievedQuestionsAndAnswers.current = true;
+    }
+  }, [filteredQuestionsAndAnswers]);
 
   return (
     <div className="view-feedback-responses-page">
@@ -178,9 +186,8 @@ const ViewFeedbackResponses = () => {
               style={{marginBottom: "0.5em", fontWeight: "bold"}}>
               Q{question.questionNumber}: {question.question}
             </Typography>
-            {question?.answers.length === 0
-              ? <div className="no-responses-found"><Typography variant="body1" style={{color: "gray"}}>No matching responses found</Typography></div>
-              : question?.answers.map(answer =>
+            {question.answers.length === 0 && retrievedQuestionsAndAnswers.current && <div className="no-responses-found"><Typography variant="body1" style={{color: "gray"}}>No matching responses found</Typography></div>}
+            {question.answers.length > 0 && question.answers.map(answer =>
                 <FeedbackResponseCard
                   key={answer.id}
                   responderId={answer.responder}

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -29,6 +29,21 @@ const useStyles = makeStyles({
   },
   popupIndicator: {
     transform: "none"
+  },
+  searchField: {
+    marginRight: "3em",
+    width: "350px",
+    ['@media (max-width: 800px)']: { // eslint-disable-line no-useless-computed-key
+      marginRight: 0,
+      width: "100%"
+    }
+  },
+  responderField: {
+    minWidth: "500px",
+    ['@media (max-width: 800px)']: { // eslint-disable-line no-useless-computed-key
+      minWidth: 0,
+      width: "100%"
+    }
   }
 }, {name: "MuiCardContent"});
 
@@ -123,7 +138,7 @@ const ViewFeedbackResponses = () => {
       </Typography>
       <div className="responses-filter-container">
         <TextField
-          style={{marginRight: "3em", width: "350px"}}
+          className={classes.searchField}
           label="Search responses..."
           placeholder="Enter a keyword or phrase"
           helperText=" "
@@ -134,13 +149,13 @@ const ViewFeedbackResponses = () => {
           }}
         />
         <Autocomplete
+          className={classes.responderField}
           classes={{popupIndicator: classes.popupIndicator}}
           multiple
           disableCloseOnSelect
           options={responderOptions}
           getOptionLabel={(responderId) => selectProfile(state, responderId).name}
           popupIcon={<GroupIcon/>}
-          style={{minWidth: "500px"}}
           value={selectedResponders}
           onChange={(event, value) => setSelectedResponders(value)}
           renderOption={(responderId, { selected }) => (

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -40,7 +40,8 @@ const ViewFeedbackResponses = () => {
   const [questionsAndAnswers, setQuestionsAndAnswers] = useState([]);
   const [searchText, setSearchText] = useState("");
   const [filteredResponders, setFilteredResponders] = useState([]);
-  const [responderOptions, setResponderOptions] = useState(["beep"]);
+  const [responderOptions, setResponderOptions] = useState([]);
+  const [selectedResponders, setSelectedResponders] = useState([]);
 
   const getFilteredResponses = useCallback(() => {
     if (!questionsAndAnswers) {
@@ -95,10 +96,12 @@ const ViewFeedbackResponses = () => {
     });
     allResponders = [...(new Set(allResponders))]  // Remove duplicate responders
 
-    allResponders = allResponders.map((responderId) => selectProfile(state, responderId).name);
-
     setResponderOptions(allResponders);
   }, [state, questionsAndAnswers]);
+
+  useEffect(() => {
+    setSelectedResponders(responderOptions);
+  }, [responderOptions]);
 
   return (
     <div className="view-feedback-responses-page">
@@ -121,11 +124,14 @@ const ViewFeedbackResponses = () => {
         <Autocomplete
           classes={{popupIndicator: classes.popupIndicator}}
           multiple
+          disableCloseOnSelect
           options={responderOptions}
-          getOptionLabel={(responder) => responder}
+          getOptionLabel={(responderId) => selectProfile(state, responderId).name}
           popupIcon={<GroupIcon/>}
           style={{width: "500px"}}
-          renderOption={(option, { selected }) => (
+          value={selectedResponders}
+          onChange={(event, value) => setSelectedResponders(value)}
+          renderOption={(responderId, { selected }) => (
             <React.Fragment>
               <Checkbox
                 icon={<CheckBoxOutlineBlankIcon fontSize="small"/>}
@@ -134,7 +140,7 @@ const ViewFeedbackResponses = () => {
                 style={{marginRight: 8}}
                 checked={selected}
               />
-              {option}
+              {selectProfile(state, responderId).name}
             </React.Fragment>
           )}
           renderInput={(params) => (
@@ -142,7 +148,7 @@ const ViewFeedbackResponses = () => {
               {...params}
               variant="standard"
               label="Filter recipients"
-              helperText={`Showing responses from 3/${responderOptions.length} recipient${responderOptions.length === 1 ? "" : "s"}`}
+              helperText={`Showing responses from ${selectedResponders.length}/${responderOptions.length} recipient${responderOptions.length === 1 ? "" : "s"}`}
             />
           )}
         />

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -1,5 +1,5 @@
 import React, {useContext, useEffect, useState} from 'react';
-import {Checkbox, TextField, Typography} from '@material-ui/core';
+import {Avatar, Checkbox, Chip, TextField, Typography} from '@material-ui/core';
 import "./ViewFeedbackResponses.css";
 import {makeStyles} from '@material-ui/core/styles';
 import FeedbackResponseCard from "./feedback_response_card/FeedbackResponseCard";
@@ -14,6 +14,7 @@ import {Group as GroupIcon, Search as SearchIcon} from "@material-ui/icons";
 import {Autocomplete} from "@material-ui/lab";
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
+import {getAvatarURL} from "../../api/api";
 
 const useStyles = makeStyles({
   root: {
@@ -154,6 +155,18 @@ const ViewFeedbackResponses = () => {
               helperText={`Showing responses from ${selectedResponders.length}/${responderOptions.length} recipient${responderOptions.length === 1 ? "" : "s"}`}
             />
           )}
+          renderTags={(value, getTagProps) =>
+            value.map((responderId, index) => {
+              const profile = selectProfile(state, responderId);
+              return (
+                <Chip
+                  avatar={<Avatar alt={`${profile.name}'s avatar`} className="large" src={getAvatarURL(profile.workEmail)}/>}
+                  label={profile.name}
+                  {...getTagProps({ index })}
+                />
+              )
+            })
+          }
         />
       </div>
       {filteredQuestionsAndAnswers.map((question) => {

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -1,5 +1,5 @@
-import React, {useContext, useEffect, useState} from 'react';
-import {Typography} from '@material-ui/core';
+import React, {useCallback, useContext, useEffect, useState} from 'react';
+import {TextField, Typography} from '@material-ui/core';
 import "./ViewFeedbackResponses.css";
 import {makeStyles} from '@material-ui/core/styles';
 import FeedbackResponseCard from "./feedback_response_card/FeedbackResponseCard";
@@ -9,22 +9,46 @@ import {useLocation} from "react-router-dom";
 import {AppContext} from "../../context/AppContext";
 import {selectCsrfToken} from "../../context/selectors";
 import {UPDATE_TOAST} from "../../context/actions";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import {Group as GroupIcon, Search as SearchIcon} from "@material-ui/icons";
 
-const useStylesCardContent = makeStyles({
+const useStyles = makeStyles({
   root: {
     '&:last-child': {
       paddingBottom: '16px',
     }
+  },
+  notFoundMessage: {
+    color: "gray",
+    marginTop: "3em",
+    textAlign: "center"
   }
 }, {name: "MuiCardContent"});
 
 const ViewFeedbackResponses = () => {
-  useStylesCardContent();
+  const classes = useStyles();
   const { state } = useContext(AppContext);
   const csrf = selectCsrfToken(state);
   const location = useLocation();
   const [query, setQuery] = useState({});
   const [questionsAndAnswers, setQuestionsAndAnswers] = useState([]);
+  const [searchText, setSearchText] = useState("");
+  const [filteredResponders, setFilteredResponders] = useState([]);
+
+  const getFilteredResponses = useCallback(() => {
+    if (!questionsAndAnswers) {
+      return null
+    } else if (questionsAndAnswers.length === 0) {
+      return <Typography className={classes.notFoundMessage} variant="h5">No responses found</Typography>
+    }
+
+    let responsesToDisplay = [];
+
+    if (responsesToDisplay.length === 0) {
+      return <Typography className={classes.notFoundMessage} variant="h5">No matching responses</Typography>
+    }
+
+  }, [questionsAndAnswers]);
 
   useEffect(() => {
     setQuery(queryString.parse(location?.search));
@@ -42,6 +66,7 @@ const ViewFeedbackResponses = () => {
 
     retrieveQuestionsAndAnswers(query.request, csrf).then((res) => {
       if (res) {
+        console.log(res);
         setQuestionsAndAnswers(res);
       } else {
         window.snackDispatch({
@@ -62,6 +87,24 @@ const ViewFeedbackResponses = () => {
         style={{textAlign: "center", marginBottom: "1em"}}>
         View Feedback for <b>Joe Johnson</b>
       </Typography>
+      <div className="responses-filter-container">
+        <TextField
+          style={{marginRight: "3em"}}
+          label="Search responses..."
+          placeholder="Enter a keyword or phrase"
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          InputProps={{
+            endAdornment: <InputAdornment style={{color: "gray"}} position="end"><SearchIcon/></InputAdornment>
+          }}
+        />
+        <TextField
+          label="Filter responders"
+          InputProps={{
+            endAdornment: <InputAdornment style={{color: "gray"}} position="end"><GroupIcon/></InputAdornment>
+          }}
+        />
+      </div>
 
       {questionsAndAnswers.map((question) => {
         return (

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -107,14 +107,15 @@ const ViewFeedbackResponses = () => {
     <div className="view-feedback-responses-page">
       <Typography
         variant='h4'
-        style={{textAlign: "center", marginBottom: "1em"}}>
+        style={{textAlign: "center", marginBottom: "0.5em"}}>
         View Feedback for <b>Joe Johnson</b>
       </Typography>
       <div className="responses-filter-container">
         <TextField
-          style={{marginRight: "3em"}}
+          style={{marginRight: "3em", width: "350px"}}
           label="Search responses..."
           placeholder="Enter a keyword or phrase"
+          helperText=" "
           value={searchText}
           onChange={(event) => setSearchText(event.target.value)}
           InputProps={{
@@ -128,7 +129,7 @@ const ViewFeedbackResponses = () => {
           options={responderOptions}
           getOptionLabel={(responderId) => selectProfile(state, responderId).name}
           popupIcon={<GroupIcon/>}
-          style={{width: "500px"}}
+          style={{minWidth: "500px"}}
           value={selectedResponders}
           onChange={(event, value) => setSelectedResponders(value)}
           renderOption={(responderId, { selected }) => (

--- a/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
+++ b/web-ui/src/components/view_feedback_responses/ViewFeedbackResponses.jsx
@@ -91,9 +91,13 @@ const ViewFeedbackResponses = () => {
   useEffect(() => {
     let responsesToDisplay = [...questionsAndAnswers];
 
-    // Filter based on selected responders
     responsesToDisplay = responsesToDisplay.map((response) => {
-      const filteredAnswers = response.answers.filter((answer) => selectedResponders.includes(answer.responder));
+      // Filter based on selected responders
+      let filteredAnswers = response.answers.filter((answer) => selectedResponders.includes(answer.responder));
+      if (searchText.trim()) {
+        // Filter based on search text
+        filteredAnswers = filteredAnswers.filter(({answer}) => answer.toLowerCase().includes(searchText.trim().toLowerCase()));
+      }
       return {...response, answers: filteredAnswers}
     });
 


### PR DESCRIPTION
To test this, log in as Geetika and go to:
```
http://localhost:3000/feedback/view/responses/?request=ab7b21d4-f88c-4494-9b0b-8541636025eb&request=2dd2347a-c296-4986-b428-3fbf6a24ea1e
```
Then test out the search field and the responders field. Responses will only show if they contain the search query and the responder is selected in the "filter recipients" field