### PR TITLE
Create received feedback requests page

### DIFF
--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestController.java
@@ -108,12 +108,13 @@ public class FeedbackRequestController {
      *
      * @param creatorId The {@link UUID} of the creator of the request
      * @param requesteeId The {@link UUID} of the requestee
+     * @param recipientId The {@link UUID} of the recipient
      * @param oldestDate The date that filters out any requests that were made before that date
      * @return list of {@link FeedbackRequestResponseDTO}
      */
-    @Get("/{?creatorId,requesteeId,oldestDate}")
-    public Single<HttpResponse<List<FeedbackRequestResponseDTO>>> findByValues(@Nullable UUID creatorId, @Nullable UUID requesteeId, @Nullable @Format("yyyy-MM-dd") LocalDate oldestDate) {
-        return Single.fromCallable(() -> feedbackReqServices.findByValues(creatorId, requesteeId, oldestDate))
+    @Get("/{?creatorId,requesteeId,recipientId,oldestDate}")
+    public Single<HttpResponse<List<FeedbackRequestResponseDTO>>> findByValues(@Nullable UUID creatorId, @Nullable UUID requesteeId, @Nullable UUID recipientId, @Nullable @Format("yyyy-MM-dd") LocalDate oldestDate) {
+        return Single.fromCallable(() -> feedbackReqServices.findByValues(creatorId, requesteeId, recipientId, oldestDate))
                 .observeOn(Schedulers.from(eventLoopGroup))
                 .map(feedbackReqs -> {
                     List<FeedbackRequestResponseDTO> dtoList = feedbackReqs.stream()

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestRepository.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestRepository.java
@@ -25,9 +25,10 @@ public interface FeedbackRequestRepository extends CrudRepository<FeedbackReques
             "FROM feedback_requests " +
             "WHERE (:creatorId IS NULL OR creator_id = :creatorId) " +
             "AND (:requesteeId IS NULL OR requestee_id = :requesteeId) " +
+            "AND (:recipientId IS NULL OR recipient_id = :recipientId) " +
             "AND (CAST(:oldestDate as date) IS NULL OR send_date >= :oldestDate) "
             ,nativeQuery = true)
-    List<FeedbackRequest> findByValues(@Nullable String creatorId, @Nullable String requesteeId, @Nullable LocalDate oldestDate);
+    List<FeedbackRequest> findByValues(@Nullable String creatorId, @Nullable String requesteeId, @Nullable String recipientId, @Nullable LocalDate oldestDate);
 
     List<FeedbackRequest> findBySendDateAfter(@Nullable LocalDate sendDate);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServices.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServices.java
@@ -13,5 +13,5 @@ public interface FeedbackRequestServices {
 
     FeedbackRequest getById(UUID id);
 
-    List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, LocalDate oldestDate);
+    List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, UUID recipientId, LocalDate oldestDate);
 }

--- a/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/feedback_request/FeedbackRequestServicesImpl.java
@@ -149,7 +149,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
     }
 
     @Override
-    public List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, LocalDate oldestDate) {
+    public List<FeedbackRequest> findByValues(UUID creatorId, UUID requesteeId, UUID recipientId, LocalDate oldestDate) {
         MemberProfile currentUser = currentUserServices.getCurrentUser();
         UUID currentUserId = currentUser.getId();
 
@@ -157,7 +157,7 @@ public class FeedbackRequestServicesImpl implements FeedbackRequestServices {
         if (currentUserId != null) {
             //users should be able to filter by only requests they have created
             if (currentUserId.equals(creatorId) || currentUserServices.isAdmin()) {
-                feedbackReqList.addAll(feedbackReqRepository.findByValues(Util.nullSafeUUIDToString(creatorId), Util.nullSafeUUIDToString(requesteeId), oldestDate));
+                feedbackReqList.addAll(feedbackReqRepository.findByValues(Util.nullSafeUUIDToString(creatorId), Util.nullSafeUUIDToString(requesteeId), Util.nullSafeUUIDToString(recipientId), oldestDate));
             } else {
                 throw new PermissionException("You are not authorized to do this operation");
             }

--- a/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImpl.java
+++ b/server/src/main/java/com/objectcomputing/checkins/services/request_notifications/CheckServicesImpl.java
@@ -35,7 +35,7 @@ public class CheckServicesImpl implements CheckServices {
     public boolean GetTodaysRequests() {
         LocalDate today = LocalDate.now();
         List<FeedbackRequest> todaysRequests = new ArrayList<>();
-        todaysRequests.addAll(feedbackReqRepository.findByValues(null, null, today));
+        todaysRequests.addAll(feedbackReqRepository.findByValues(null, null, null, today));
         for (FeedbackRequest req: todaysRequests) {
             String newContent =  notificationContent + "<a href=\""+submitURL+req.getId()+"\">Check-Ins application</a>.";
             emailSender.sendEmail(notificationSubject, newContent);

--- a/server/src/main/resources/db/dev/R__Load_testing_data.sql
+++ b/server/src/main/resources/db/dev/R__Load_testing_data.sql
@@ -85,6 +85,11 @@ INSERT INTO member_profile
 VALUES
 ('066b186f-1425-45de-89f2-4ddcc6ebe237', PGP_SYM_ENCRYPT('Joe','${aeskey}'), PGP_SYM_ENCRYPT('Warner','${aeskey}'), PGP_SYM_ENCRYPT('Software Engineer','${aeskey}'), '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d', PGP_SYM_ENCRYPT('St. Louis','${aeskey}'), PGP_SYM_ENCRYPT('warnerj@objectcomputing.com','${aeskey}'), '123123413', '2012-09-29', PGP_SYM_ENCRYPT('Engineer of Supreme Ability','${aeskey}'), null);
 
+INSERT INTO member_profile
+(id, firstName, lastName, title, pdlid, location, workEmail, employeeid, startdate, biotext, supervisorid)
+VALUES
+('aba9d6d8-0f8d-4b0f-9eca-209a62ee2dae', PGP_SYM_ENCRYPT('Michael','${aeskey}'), PGP_SYM_ENCRYPT('Pieper','${aeskey}'), PGP_SYM_ENCRYPT('Intern','${aeskey}'), null, PGP_SYM_ENCRYPT('St. Louis','${aeskey}'), PGP_SYM_ENCRYPT('pieperm@objectcomputing.com','${aeskey}'), '123123414', '2021-05-17', PGP_SYM_ENCRYPT('Interning and learning a lot','${aeskey}'), null);
+
 INSERT INTO role
 (id, role, memberid)
 VALUES
@@ -509,3 +514,18 @@ INSERT INTO feedback_requests
 (id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
 VALUES
 ('e2af1c96-a593-48c2-b9e0-a00193a070c7', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498', '8fa673c0-ca19-4271-b759-41cb9db2e83a', '43ee8e79-b33d-44cd-b23c-e183894ebfef','18ef2032-c264-411e-a8e1-ddda9a714bae', '2021-08-01', '2021-08-05', '2021-08-02', 'submitted');
+
+INSERT INTO feedback_requests
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
+VALUES
+('3444fbbc-3daf-4343-a3b2-8eef64a387de', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9', '2559a257-ae84-4076-9ed4-3820c427beeb', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498','18ef2032-c264-411e-a8e1-ddda9a714bae', '2021-08-10', '2021-08-20', '2021-08-15', 'submitted');
+
+INSERT INTO feedback_requests
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
+VALUES
+('7cc1d9a8-233b-4d02-9286-95e16e61cf35', '01b7d769-9fa2-43ff-95c7-f3b950a27bf9', '2559a257-ae84-4076-9ed4-3820c427beeb', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498','18ef2032-c264-411e-a8e1-ddda9a714bae', '2021-07-24', '2021-09-30', null, 'sent');
+
+INSERT INTO feedback_requests
+(id, creator_id, requestee_id, recipient_id, template_id, send_date, due_date, submit_date, status)
+VALUES
+('4fc07d87-55ff-4f5b-8c81-fae070deec65', '2c1b77e2-e2fc-46d1-92f2-beabbd28ee3d', '066b186f-1425-45de-89f2-4ddcc6ebe237', '7a6a2d4e-e435-4ec9-94d8-f1ed7c779498','18ef2032-c264-411e-a8e1-ddda9a714bae', '2021-05-05', null, '2021-05-17', 'submitted');

--- a/web-ui/src/api/feedback.js
+++ b/web-ui/src/api/feedback.js
@@ -131,3 +131,14 @@ export const getFeedbackRequestsByCreator = async(creatorId, cookie) => {
     headers: { "X-CSRF-Header": cookie }
   });
 }
+
+export const getFeedbackRequestsByRecipient = async(recipientId, cookie) => {
+  return resolve({
+    url: feedbackRequestURL,
+    params: {
+      recipientId: recipientId
+    },
+    responseType: "json",
+    headers: { "X-CSRF-Header": cookie }
+  });
+}

--- a/web-ui/src/components/menu/Menu.jsx
+++ b/web-ui/src/components/menu/Menu.jsx
@@ -75,6 +75,11 @@ const directoryLinks = [
   ["/teams", "Teams"],
 ];
 
+const feedbackLinks = [
+  ["/feedback/view", "View Feedback"],
+  ["/feedback/received-requests", "Received Requests"]
+];
+
 const reportsLinks = [
   ["/checkins-reports", "Check-ins"],
   ["/skills-reports", "Skills"],
@@ -108,7 +113,10 @@ function Menu() {
   );
   const [reportsOpen, setReportsOpen] = useState(
     isCollapsibleListOpen(reportsLinks, location.pathname)
-    );
+  );
+  const [feedbackOpen, setFeedbackOpen] = useState(
+    isCollapsibleListOpen(feedbackLinks, location.pathname)
+  )
   const anchorRef = useRef(null);
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
@@ -132,6 +140,10 @@ function Menu() {
     setReportsOpen(!reportsOpen);
   };
 
+  const toggleFeedback = () => {
+    setFeedbackOpen(!feedbackOpen);
+  }
+
   const toggleDirectory = () => {
     setDirectoryOpen(!directoryOpen);
   };
@@ -139,6 +151,7 @@ function Menu() {
   const closeSubMenus = () => {
     setReportsOpen(false);
     setDirectoryOpen(false);
+    setFeedbackOpen(false);
   };
 
   const isLinkSelected = (path) => {
@@ -201,7 +214,20 @@ function Menu() {
         <Collapse in={directoryOpen} timeout="auto" unmountOnExit>
           {createListJsx(directoryLinks, true)}
         </Collapse>
-      {(isAdmin || isPDL) && createLinkJsx("/feedback/view", "FEEDBACK", false)}
+      {(isAdmin || isPDL) && (
+        <React.Fragment>
+          <ListItem
+            button
+            onClick={toggleFeedback}
+            className={classes.listItem}
+          >
+            <ListItemText primary="FEEDBACK" />
+          </ListItem>
+          <Collapse in={feedbackOpen} timeout="auto" unmountOnExit>
+            {createListJsx(feedbackLinks, true)}
+          </Collapse>
+        </React.Fragment>
+      )}
       {isAdmin && (
           <React.Fragment>
             <ListItem

--- a/web-ui/src/components/menu/__snapshots__/Menu.test.js.snap
+++ b/web-ui/src/components/menu/__snapshots__/Menu.test.js.snap
@@ -966,10 +966,9 @@ exports[`<Menu /> renders correctly for admin 1`] = `
                   </div>
                 </div>
               </div>
-              <a
+              <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
-                href="/feedback/view"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -997,7 +996,7 @@ exports[`<Menu /> renders correctly for admin 1`] = `
                 <span
                   className="MuiTouchRipple-root"
                 />
-              </a>
+              </div>
               <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
@@ -1342,10 +1341,9 @@ exports[`<Menu /> renders correctly for admin 1`] = `
                   </div>
                 </div>
               </div>
-              <a
+              <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
-                href="/feedback/view"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -1373,7 +1371,7 @@ exports[`<Menu /> renders correctly for admin 1`] = `
                 <span
                   className="MuiTouchRipple-root"
                 />
-              </a>
+              </div>
               <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
@@ -1785,10 +1783,9 @@ exports[`<Menu /> renders correctly for pdl 1`] = `
                   </div>
                 </div>
               </div>
-              <a
+              <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
-                href="/feedback/view"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -1813,7 +1810,7 @@ exports[`<Menu /> renders correctly for pdl 1`] = `
                     FEEDBACK
                   </span>
                 </div>
-              </a>
+              </div>
             </nav>
           </div>
         </div>
@@ -2045,10 +2042,9 @@ exports[`<Menu /> renders correctly for pdl 1`] = `
                   </div>
                 </div>
               </div>
-              <a
+              <div
                 aria-disabled={false}
                 className="MuiButtonBase-root MuiListItem-root MuiListItem-gutters MuiListItem-button"
-                href="/feedback/view"
                 onBlur={[Function]}
                 onClick={[Function]}
                 onDragLeave={[Function]}
@@ -2073,7 +2069,7 @@ exports[`<Menu /> renders correctly for pdl 1`] = `
                     FEEDBACK
                   </span>
                 </div>
-              </a>
+              </div>
             </nav>
           </div>
         </div>

--- a/web-ui/src/components/received_request_card/ReceivedRequestCard.jsx
+++ b/web-ui/src/components/received_request_card/ReceivedRequestCard.jsx
@@ -1,0 +1,104 @@
+import React, {useContext} from "react";
+import {Avatar, Card, Tooltip, IconButton} from "@material-ui/core";
+import {getAvatarURL} from "../../api/api";
+import Typography from "@material-ui/core/Typography";
+import {Link} from "react-router-dom";
+import PropTypes from "prop-types";
+import {selectProfile} from "../../context/selectors";
+import DateFnsUtils from "@date-io/date-fns";
+import {AppContext} from "../../context/AppContext";
+import {makeStyles} from "@material-ui/core/styles";
+import {Edit as EditIcon} from "@material-ui/icons";
+
+const dateFns = new DateFnsUtils();
+
+const useStyles = makeStyles({
+  redTypography: {
+    color: "#FF0000"
+  },
+  yellowTypography: {
+    color: "#EE8C00"
+  },
+  greenTypography: {
+    color: "#006400"
+  },
+  darkGrayTypography: {
+    color: "#333333"
+  }
+});
+
+const propTypes = {
+  request: PropTypes.object.isRequired
+};
+
+const ReceivedRequestCard = ({ request }) => {
+  let { submitDate, dueDate, sendDate } = request;
+  const { state } = useContext(AppContext);
+  const classes = useStyles();
+  const requestCreator = selectProfile(state, request?.creatorId);
+  const requestee = selectProfile(state, request?.requesteeId);
+  submitDate = submitDate ? dateFns.format(new Date(submitDate.join("-")), "MM/dd/yyyy") : null;
+  dueDate = dueDate ? dateFns.format(new Date(dueDate.join("-")), "LLLL dd, yyyy") : null;
+  sendDate = dateFns.format(new Date(sendDate.join("-")), "LLLL dd, yyyy");
+
+  const Submitted = () => {
+    if (request.dueDate) {
+      const today = new Date();
+      const due = new Date(request.dueDate);
+      if (!request.submitDate && today > due) {
+        return <Typography className={classes.redTypography}>Overdue</Typography>;
+      }
+    }
+    if (request.submitDate) {
+      return <Typography className={classes.greenTypography}>Submitted {submitDate}</Typography>;
+    } else
+      return <Typography className={classes.yellowTypography}>Not Submitted</Typography>;
+  }
+
+  return (
+    <Card style={{paddingLeft: "16px", paddingRight: "16px"}}>
+      <div className="card-content-grid">
+        <div className="request-members-container">
+          <div className="member-chip">
+            <Avatar style={{width: "40px", height: "40px", marginRight: "0.5em"}} src={getAvatarURL(requestCreator?.workEmail)}/>
+            <div>
+              <Typography className="person-name">{requestCreator?.name}</Typography>
+              <Typography className="position-text" style={{fontSize: "14px"}}>{requestCreator?.title}</Typography>
+            </div>
+          </div>
+          <Typography style={{margin: "0 5px 0 5px"}} variant="body1">requested feedback on</Typography>
+          <div className="member-chip">
+            <Avatar style={{width: "40px", height: "40px", marginRight: "0.5em"}} src={getAvatarURL(requestee?.workEmail)}/>
+            <div>
+              <Typography className="person-name">{requestee?.name}</Typography>
+              <Typography className="position-text" style={{fontSize: "14px"}}>{requestee?.title}</Typography>
+            </div>
+          </div>
+        </div>
+        <div className="request-details-container">
+          <div className="request-dates-container">
+            <Typography className={classes.darkGrayTypography} variant= "body1">Sent on {sendDate}</Typography>
+            <Typography variant="body2">{request?.dueDate ? `Due on ${dueDate}` : "No due date"}</Typography>
+          </div>
+          <div className="request-status-container">
+            <Submitted/>
+          </div>
+          <div className="submission-link-container">
+            {request && !request.submitDate && request.id
+              ? (
+                <Link to={`/feedback/submit?request=${request.id}`} style={{textDecoration: "none"}}>
+                  <Tooltip title="Give feedback" arrow>
+                    <IconButton><EditIcon/></IconButton>
+                  </Tooltip>
+                </Link>
+              )
+              : null}
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+ReceivedRequestCard.propTypes = propTypes;
+
+export default ReceivedRequestCard;

--- a/web-ui/src/components/routes/Routes.jsx
+++ b/web-ui/src/components/routes/Routes.jsx
@@ -24,6 +24,7 @@ import ViewFeedbackPage from "../../pages/ViewFeedbackPage";
 import ViewFeedbackResponses from "../view_feedback_responses/ViewFeedbackResponses";
 import FeedbackSubmitConfirmation from "../feedback_submit_confirmation/FeedbackSubmitConfirmation";
 import FeedbackSubmitPage from "../../pages/FeedbackSubmitPage";
+import ReceivedRequestsPage from "../../pages/ReceivedRequestsPage";
 
 
 export default function Routes() {
@@ -78,6 +79,9 @@ export default function Routes() {
       </Route>
       <Route path="/feedback/submit">
         <FeedbackSubmitPage />
+      </Route>
+      <Route path="/feedback/received-requests">
+        <ReceivedRequestsPage />
       </Route>
 
       {isAdmin && (

--- a/web-ui/src/pages/ReceivedRequestsPage.css
+++ b/web-ui/src/pages/ReceivedRequestsPage.css
@@ -1,0 +1,143 @@
+.received-requests-page {
+  margin-top: 4em;
+  padding: 0 8em 2em 8em;
+  width: 100%;
+}
+
+.received-requests-page .received-requests-header-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2em;
+  flex-wrap: wrap;
+}
+
+.received-requests-page .received-requests-filter-container {
+  display: grid;
+  grid-template-columns: 360px 260px;
+  align-items: end;
+  grid-column-gap: 1em;
+}
+
+.received-requests-page .request-section-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 4em;
+}
+
+.received-requests-page .received-requests-container {
+  margin-top: 1em;
+}
+
+.received-requests-page .submitted-requests-container {
+  margin-top: 1em;
+  margin-bottom: 2em;
+}
+
+.received-requests-page .no-requests-message {
+  background-color: #e5e5e5;
+  color: gray;
+  border-radius: 4px;
+  padding: 10px;
+  text-align: center;
+}
+
+.received-requests-page .card-content-grid {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.received-requests-page .card-content-grid .request-members-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.received-requests-page .request-members-container .member-chip {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 5px 30px 5px 10px;
+  margin: 10px;
+  border-radius: 40px;
+  background-color: #e5e5e5;
+}
+
+.received-requests-page .card-content-grid .request-details-container {
+  display: grid;
+  grid-template-columns: 230px 170px 40px;
+  align-items: center;
+}
+
+.received-requests-page .card-content-grid .request-dates-container {
+  margin-left: 1em;
+}
+
+.received-requests-page .card-content-grid .request-status-container {
+  text-align: center;
+}
+
+.received-requests-page .card-content-grid .submission-link-container {
+  width: 100%;
+  text-align: right;
+}
+
+@media screen and (max-width: 1600px) {
+  .received-requests-page {
+    padding: 0 4em 2em 4em;
+  }
+}
+
+@media screen and (max-width: 1370px) {
+  .received-requests-page .received-requests-filter-container {
+    margin-top: 1em;
+  }
+}
+
+@media screen and (max-width: 840px) {
+  .received-requests-page {
+    padding: 0 2em 2em 2em;
+  }
+
+  .received-requests-page .received-requests-filter-container {
+    grid-template-rows: 50px 50px;
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+}
+
+@media screen and (max-width: 1100px) {
+  .received-requests-page .card-content-grid .request-members-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .received-requests-page .request-members-container .member-chip {
+    margin-left: 0;
+  }
+}
+
+@media screen and (max-width: 530px) {
+  .received-requests-page .card-content-grid .request-members-container {
+    align-items: center;
+  }
+
+  .received-requests-page .card-content-grid .request-details-container {
+    grid-template-rows: 50px 50px;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+    align-items: center;
+    justify-items: center;
+  }
+
+  .received-requests-page .card-content-grid .request-dates-container {
+    grid-column: 1 / span 2;
+  }
+}

--- a/web-ui/src/pages/ReceivedRequestsPage.jsx
+++ b/web-ui/src/pages/ReceivedRequestsPage.jsx
@@ -1,0 +1,247 @@
+import React, {useContext, useEffect, useState} from "react";
+import {AppContext} from "../context/AppContext";
+import {selectCsrfToken, selectCurrentUserId, selectProfile} from "../context/selectors";
+import FormControl from "@material-ui/core/FormControl";
+import TextField from "@material-ui/core/TextField";
+import MenuItem from "@material-ui/core/MenuItem";
+import {makeStyles} from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import {Search as SearchIcon} from "@material-ui/icons";
+import {Collapse, IconButton, InputAdornment} from "@material-ui/core";
+import ReceivedRequestCard from "../components/received_request_card/ReceivedRequestCard";
+import {getFeedbackRequestsByRecipient} from "../api/feedback";
+import "./ReceivedRequestsPage.css";
+import {UPDATE_TOAST} from "../context/actions";
+import Divider from "@material-ui/core/Divider";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+
+const useStyles = makeStyles({
+  pageTitle: {
+    paddingRight: "0.4em",
+    minWidth: "330px",
+    ['@media screen and (max-width: 600px)']: { // eslint-disable-line no-useless-computed-key
+      fontSize: "30px",
+      width: "100%",
+      padding: 0,
+      textAlign: "center",
+      minWidth: "10px"
+    },
+  },
+  textField: {
+    width: "100%",
+  },
+  searchField: {
+    width: "100%",
+    ['@media screen and (max-width: 840px)']: { // eslint-disable-line no-useless-computed-key
+      marginBottom: "1em"
+    },
+  },
+  formControl: {
+    marginRight: "1em"
+  },
+  notFoundMessage: {
+    color: "gray",
+    marginTop: "4em",
+    textAlign: "center"
+  },
+  expandClose: {
+    transform: 'rotate(0deg)',
+    marginLeft: 'auto',
+    transition: "transform 0.1s linear",
+  },
+  expandOpen: {
+    transform: 'rotate(180deg)',
+    transition: "transform 0.1s linear",
+    marginLeft: 'auto',
+  }
+});
+
+const SortOption = {
+  DATE_DESCENDING: "date_descending",
+  DATE_ASCENDING: "date_ascending"
+};
+
+const ReceivedRequestsPage = () => {
+  const {state} = useContext(AppContext);
+  const csrf = selectCsrfToken(state);
+  const classes = useStyles();
+  const [searchText, setSearchText] = useState("");
+  const [sortValue, setSortValue] = useState(SortOption.DATE_DESCENDING);
+  const [receivedRequests, setReceivedRequests] = useState([]);
+  const [filteredReceivedRequests, setFilteredReceivedRequests] = useState([]);
+  const [submittedRequests, setSubmittedRequests] = useState([]);
+  const [filteredSubmittedRequests, setFilteredSubmittedRequests] = useState([]);
+  const [receivedRequestsExpanded, setReceivedRequestsExpanded] = useState(true);
+  const [submittedRequestsExpanded, setSubmittedRequestsExpanded] = useState(false);
+  const currentUserId =  selectCurrentUserId(state);
+
+  useEffect(() => {
+    const getAllFeedbackRequests = async () => {
+      let res = await getFeedbackRequestsByRecipient(currentUserId, csrf);
+      if (res && res.payload && res.payload.data && !res.error) {
+        return res.payload.data;
+      } else {
+        window.snackDispatch({
+          type: UPDATE_TOAST,
+          payload: {
+            severity: "error",
+            toast: res.error
+          },
+        });
+      }
+    }
+
+    if (csrf && currentUserId) {
+      getAllFeedbackRequests().then((data) => {
+        if (data) {
+          setReceivedRequests(data.filter((req) => req.submitDate === undefined));
+          setSubmittedRequests(data.filter((req) => req.submitDate && req.submitDate.length === 3));
+        }
+      });
+    }
+
+  }, [csrf, currentUserId]);
+
+  useEffect(() => {
+    let filteredReceived = [...receivedRequests];
+    let filteredSubmitted = [...submittedRequests];
+
+    // Search for intersection of multiple queries separated by commas
+    const queries = searchText.split(",").map((search) => search.trim().toLowerCase());
+
+    if (searchText.trim()) {
+      for (let query of queries) {
+        filteredReceived = filteredReceived.filter((request) => {
+          const creatorName = selectProfile(state, request.creatorId).name.toLowerCase();
+          const requesteeName = selectProfile(state, request.requesteeId).name.toLowerCase();
+          return creatorName.includes(query) || requesteeName.includes(query);
+        });
+
+        filteredSubmitted = filteredSubmitted.filter((request) => {
+          const creatorName = selectProfile(state, request.creatorId).name.toLowerCase();
+          const requesteeName = selectProfile(state, request.requesteeId).name.toLowerCase();
+          return creatorName.includes(query) || requesteeName.includes(query);
+        });
+      }
+    }
+
+    // Sort according to selected sort option
+    let sortMethod;
+    if (sortValue === SortOption.DATE_ASCENDING) {
+      sortMethod = (a, b) => (new Date(a.sendDate) > new Date(b.sendDate) ? 1 : -1);
+    } else if (sortValue === SortOption.DATE_DESCENDING) {
+      sortMethod = (a, b) => (new Date(a.sendDate) > new Date(b.sendDate) ? -1 : 1);
+    }
+
+    filteredReceived.sort(sortMethod);
+    filteredSubmitted.sort(sortMethod);
+
+    setFilteredReceivedRequests(filteredReceived);
+    setFilteredSubmittedRequests(filteredSubmitted);
+
+  }, [state, receivedRequests, submittedRequests, searchText, sortValue]);
+
+  return (
+    <div className="received-requests-page">
+      <div className="received-requests-header-container">
+        <Typography variant="h4" className={classes.pageTitle}>Received Feedback Requests</Typography>
+        <div className="received-requests-filter-container">
+          <TextField
+            className={classes.searchField}
+            placeholder="Alice, Bob, Eve..."
+            label="Search..."
+            value={searchText}
+            onChange={(event) => {
+              setSearchText(event.target.value);
+              setReceivedRequestsExpanded(true);
+              setSubmittedRequestsExpanded(true);
+            }}
+            InputProps={{
+              endAdornment: <InputAdornment style={{color: "gray"}} position="end"><SearchIcon/></InputAdornment>
+            }}
+          />
+
+          <FormControl
+            className={classes.textField}
+            value={sortValue}
+          >
+            <TextField
+              id="select-sort-method"
+              select
+              size="small"
+              label="Sort by"
+              fullWidth
+              onChange={(e) => setSortValue(e.target.value)}
+              defaultValue={SortOption.DATE_ASCENDING}
+              variant="outlined"
+            >
+              <MenuItem value={SortOption.DATE_DESCENDING}>Send date (least recent)</MenuItem>
+              <MenuItem value={SortOption.DATE_ASCENDING}>Send date (most recent)</MenuItem>
+            </TextField>
+          </FormControl>
+        </div>
+      </div>
+      <div className="request-section-header">
+        <Typography variant="h5">Received Requests</Typography>
+        <IconButton
+          onClick={() => setReceivedRequestsExpanded(!receivedRequestsExpanded)}
+          aria-label="show more"
+          className={receivedRequestsExpanded ? classes.expandOpen : classes.expandClose}
+        >
+          <ExpandMoreIcon/>
+        </IconButton>
+      </div>
+      <Divider/>
+      <Collapse in={!receivedRequestsExpanded} timeout="auto" unmountOnExit>
+        <div style={{marginTop: "1em"}} className="no-requests-message">
+          <Typography variant="body1">{receivedRequests.length} received request{receivedRequests.length === 1 ? "" : "s"} currently hidden</Typography>
+        </div>
+      </Collapse>
+      <Collapse in={receivedRequestsExpanded} timeout="auto" unmountOnExit>
+        <div className="received-requests-container">
+          {receivedRequests.length === 0 &&
+          <div className="no-requests-message"><Typography variant="body1">No received feedback requests</Typography></div>
+          }
+          {receivedRequests.length > 0 && filteredReceivedRequests.length === 0 &&
+          <div className="no-requests-message"><Typography variant="body1">No matching feedback requests</Typography></div>
+          }
+          {filteredReceivedRequests.map((request) => (
+            <ReceivedRequestCard key={request.id} request={request}/>
+          ))}
+        </div>
+      </Collapse>
+      <div className="request-section-header">
+        <Typography variant="h5">Submitted Requests</Typography>
+        <IconButton
+          onClick={() => setSubmittedRequestsExpanded(!submittedRequestsExpanded)}
+          aria-label="show more"
+          className={submittedRequestsExpanded ? classes.expandOpen : classes.expandClose}
+        >
+          <ExpandMoreIcon/>
+        </IconButton>
+      </div>
+      <Divider/>
+      <Collapse in={!submittedRequestsExpanded} timeout="auto" unmountOnExit>
+        <div style={{marginTop: "1em"}} className="no-requests-message">
+          <Typography variant="body1">{submittedRequests.length} submitted request{submittedRequests.length === 1 ? "" : "s"} currently hidden</Typography>
+        </div>
+      </Collapse>
+      <Collapse in={submittedRequestsExpanded} timeout="auto" unmountOnExit>
+        <div className="submitted-requests-container">
+          {submittedRequests.length === 0 &&
+          <div className="no-requests-message"><Typography variant="body1">No submitted feedback requests</Typography></div>
+          }
+          {submittedRequests.length > 0 && filteredSubmittedRequests.length === 0 &&
+          <div className="no-requests-message"><Typography variant="body1">No submitted feedback requests</Typography></div>
+          }
+          {filteredSubmittedRequests.map((request) => (
+            <ReceivedRequestCard key={request.id} request={request}/>
+          ))}
+        </div>
+      </Collapse>
+    </div>
+  );
+
+}
+
+export default ReceivedRequestsPage;


### PR DESCRIPTION
To test this, log in as Geetika, and go to:
```
localhost:3000/feedback/received-requests
```

There should be one section for received feedback requests and one section for submitted feedback requests. These sections can be expanded/closed. The search bar and the sort filter should work as expected (you can separate names with commas to narrow the search for more names!)

For any un-submitted requests, there should be a pencil icon that redirects to the submission flow for that request. The submitted requests don't have any icon.