### PR TITLE
chore: introduce app-wide type definitions

### DIFF
--- a/web-ui/src/app.d.js
+++ b/web-ui/src/app.d.js
@@ -1,0 +1,28 @@
+// Type definitions specified here will be available app-wide
+
+/**
+ * @typedef {Object} MemberProfile
+ * @property {?string} bioText
+ * @property {?Array} birthday
+ * @property {string} employeeId
+ * @property {?string} excluded
+ * @property {string} firstName
+ * @property {!string} id
+ * @property {string} lastName
+ * @property {string} location
+ * @property {?string} middleName
+ * @property {string} name
+ * @property {?string} pdlId
+ * @property {Array} startDate
+ * @property {?string} suffix
+ * @property {?string} supervisorid
+ * @property {?Array} terminationDate
+ * @property {string} title
+ * @property {?string} voluntary
+ * @property {string} workEmail
+ */
+
+/**
+ * @typedef {MemberProfile} PDLProfile
+ * @property {string} pdlId
+ */


### PR DESCRIPTION
In support of #2212 this pull introduces app-wide type definitions to the codebase and specifies the `Member` and `PDL` types. Information on nullable and non-nullable types can be found here: https://jsdoc.app/tags-type